### PR TITLE
Add needed dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,17 @@
     "@types/node": "^7.0.5",
     "bluebird": "^3.4.7",
     "discord.js": "^11.0.0",
+    "erlpack": "hammerandchisel/erlpack#master",
     "js-yaml": "^3.8.1",
     "marked": "^0.3.6",
+    "matrix-appservice-bridge": "^1.3.5",
     "mime": "^1.3.4",
+    "node-opus": "^0.2.0",
     "npmlog": "^4.0.2",
+    "opusscript": "^0.0.1",
     "tslint": "^4.4.2",
     "typescript": "^2.1.6",
-    "matrix-appservice-bridge": "^1.3.5"
+    "uws": "^0.12.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
After running `npm install` I got these warnings. I assume you just forgot to add them to the dependencies list.
```
npm WARN discord.js@11.0.0 requires a peer of erlpack@hammerandchisel/erlpack#master but none was installed.
npm WARN discord.js@11.0.0 requires a peer of node-opus@^0.2.0 but none was installed.
npm WARN discord.js@11.0.0 requires a peer of opusscript@^0.0.1 but none was installed.
npm WARN discord.js@11.0.0 requires a peer of uws@^0.12.0 but none was installed.
```