### PR TITLE
Set display name and avatar on initial join and handle joining/leaving guild members

### DIFF
--- a/src/matrixroomhandler.ts
+++ b/src/matrixroomhandler.ts
@@ -54,9 +54,8 @@ export class MatrixRoomHandler {
         if (member.id === this.discord.GetBotId()) {
           continue;
         }
-        const intent = this.bridge.getIntentFromLocalpart(`_discord_${member.id}`);
         promiseChain = promiseChain.return(Bluebird.delay(delay).then(() => {
-          return intent.join(roomId);
+          return this.discord.InitJoinUser(member, roomId);
         }));
         delay += JOIN_DELAY;
       }

--- a/src/matrixroomhandler.ts
+++ b/src/matrixroomhandler.ts
@@ -55,7 +55,7 @@ export class MatrixRoomHandler {
           continue;
         }
         promiseChain = promiseChain.return(Bluebird.delay(delay).then(() => {
-          return this.discord.InitJoinUser(member, roomId);
+          return this.discord.InitJoinUser(member, [roomId]);
         }));
         delay += JOIN_DELAY;
       }


### PR DESCRIPTION
Previously the avatar and user name of a bridged discord user were only set on their matrix user after the first message.
Per guild display names were only set after the discord user changed their display name.

The first commit changes the initial auto-joining of users into a new matrix room to also set their avatar, user name and display name.


The second commit handles discord users that join/leave guilds by joining/parting their matrix counterparts into/from the respective matrix rooms.
In its current form, this will probably break if multiple discord channels were to be bridged to the same matrix channel; not sure if this configuration should be supported.