### PR TITLE
Fix schema version update failure

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -55,8 +55,7 @@ export class DiscordStore {
   public async init (overrideSchema: number = 0) {
     log.info("DiscordStore", "Starting DB Init");
     await this.open_database();
-    const oldVersion = await this.getSchemaVersion();
-    let version = oldVersion;
+    let version = await this.getSchemaVersion();
     const targetSchema = overrideSchema || CURRENT_SCHEMA;
     while (version < targetSchema) {
       version++;
@@ -79,7 +78,7 @@ export class DiscordStore {
         throw Error("Failure to update to latest schema.");
       }
       this.version = version;
-      await this.setSchemaVersion(oldVersion, version);
+      await this.setSchemaVersion(version);
     }
     log.info("DiscordStore", "Updated database to the latest schema");
   }
@@ -229,14 +228,13 @@ export class DiscordStore {
     });
   }
 
-  private setSchemaVersion (oldVer: number, ver: number): Promise<any> {
+  private setSchemaVersion (ver: number): Promise<any> {
     log.silly("DiscordStore", "_set_schema_version => %s", ver);
     return this.db.getAsync(
       `
       UPDATE schema
       SET version = $ver
-      WHERE version = $old_ver
-      `, {$ver: ver, $old_ver: oldVer},
+      `, {$ver: ver},
     );
   }
 


### PR DESCRIPTION
## Issue
On fresh installs, starting the appservice after the initial run, (without first removing the discord.db) causes the db upgrade to fail because some table already exists.

## Cause
The loop in `store#init(number)` upgrades the current db schema one version at a time. After each iteration, it updates the current schema version stored in the db. This update query is restricted to only update rows where the `version` column matches the old schema version.

This is fine for the first call (`this.setSchemaVersion(0, 1)`) but does nothing for the second call (`this.setSchemaVersion(0, 2)`) because the `oldVersion` in the loop never changes while the version in the db has changed.
This results in the final stored schema version to be `1` even though the db was actually successfully upgraded to `3` (or whatever the most recent one is). On the next startup, the upgrade from `1` is re-applied which fails as expected.

## Fix
One solution would have been to increment the `oldVersion` on every iteration of the loop (or just replace it by `version - 1`).
However, I couldn't see any good reason for keeping the `oldVersion` around in the first place, so this PR just removes it altogether.