### PR TITLE
Add config option to specify default directory listing

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -9,3 +9,5 @@ logging:
   level: "warn" #silly, verbose, info, http, warn, error
 database:
   filename: "discord.db"
+room:
+  defaultVisibility: "public"

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -32,3 +32,9 @@ properties:
         properties:
           filename:
             type: "string"
+    room:
+        type: "object"
+        required: ["defaultVisibility"]
+        properties:
+          defaultVisibility:
+            type: "string"

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,7 @@ export class DiscordBridgeConfig {
   public auth: DiscordBridgeConfigAuth;
   public logging: DiscordBridgeConfigLogging;
   public database: DiscordBridgeConfigDatabase;
+  public room: DiscordBridgeConfigRoom;
 }
 
 class DiscordBridgeConfigBridge {
@@ -23,4 +24,8 @@ export class DiscordBridgeConfigAuth {
 }
 class DiscordBridgeConfigLogging {
   public level: string;
+}
+
+class DiscordBridgeConfigRoom {
+  public defaultVisibility: string;
 }

--- a/src/matrixroomhandler.ts
+++ b/src/matrixroomhandler.ts
@@ -175,7 +175,7 @@ export class MatrixRoomHandler {
     remote.set("update_name", true);
     remote.set("update_topic", true);
     const creationOpts = {
-      visibility: "public",
+      visibility: this.config.room.defaultVisibility,
       room_alias_name: alias,
       name: `[Discord] ${channel.guild.name} #${channel.name}`,
       topic: channel.topic ? channel.topic : "",


### PR DESCRIPTION
This commit adds a new section and option in `config.yaml` for rooms and whether
they should be shown in the HS' public directory listing by default.

The default behavior is to show them.

Fixes #38.