### PR TITLE
Manually handle joining of discord users into rooms (fixes #56)

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -463,7 +463,7 @@ export class DiscordBot {
     });
   }
 
-  private UpdateGuildMember(guildMember: Discord.GuildMember, roomIds?: string[]) : Bluebird<any> {
+  private UpdateGuildMember(guildMember: Discord.GuildMember, roomIds?: string[]): Bluebird<any> {
     const intent = this.GetIntentFromDiscordMember(guildMember);
     const client = intent.getClient();
     const userId = client.credentials.userId;

--- a/src/discordas.ts
+++ b/src/discordas.ts
@@ -64,6 +64,11 @@ function run (port: number, config: DiscordBridgeConfig) {
         log.verbose("matrix-appservice-bridge", line);
       },
     },
+    intentOptions: {
+      clients: {
+        dontJoin: true, // handled manually in DiscordBot#UpdateGuildMember
+      },
+    },
     domain: config.bridge.domain,
     homeserverUrl: config.bridge.homeserverUrl,
     registration,


### PR DESCRIPTION
#56 
### What's the problem?
On the first action (i.e. typing or message) of a Discord user after an appservice restart, their Matrix display name is unintentionally set to their Discord user name+tag (which is their Matrix user name).
Additionally their display name is never corrected until they change their display name on Discord.

### Why is that?
Each `Intent` instance has a cache for the membership state of its user for all channels.
When a channel is not yet in that cache (i.e. after appservice restart), the user is assumed to not yet be part of that channel. So whenever an action for that user is to be performed for such a channel, the Intent tries to join the user into the channel and uses their Matrix user name (= discord name+tag) to do so hence changing their Matrix display name to be their Matrix user name.

### How does this PR fix the issue?
Luckily there's an option in matrix-appservice-bridge which allows disabling of its auto-join feature (setting `dontJoin` for the client intents to `true`).
This requires us to manually join the users into their channels before we bridge their messages which `UpdateGuildMember` basically already does.

So apart from setting `dontJoin` this PR also does the following:
- Remove the old `intent.join` call when a user initially joins a room (now handled by `UpdateGuildMember`)
- Change `UpdateGuildMember` to return a promise, so we can be sure the user is actually joined before sending their messages
- Ensure the user is joined before trying to bridge their message in `OnMessage` (while not strictly required, this becomes necessary when the bot is missing member events due to it being offline and to update users which have been previously affected by the bug or some other bug that caused them to not yet be in the room)
- Have `UpdateGuildMember` invite the client if necessary (i.e. the channel has been set to be invite-only), this used to be done by the Intent but no longer is due to `dontJoin`

This will send an additional member state event with every message, however Synapse should quickly drop those because they are identical to the current state.

`UpdateGuildMember` isn't called for typing notifications because it is only really required in case the user has been affected by the bug or is not yet in the room. In either case the price for not calling it on typing notifs is minimal and it's permanently fixed with the next message they sent.