### PR TITLE
Fix bot starting before user/room store is initialized

### DIFF
--- a/src/discordas.ts
+++ b/src/discordas.ts
@@ -72,9 +72,10 @@ function run (port: number, config: DiscordBridgeConfig) {
   discordbot.setBridge(bridge);
   log.info("discordas", "Initing bridge.");
   log.info("AppServ", "Started listening on port %s at %s", port, new Date().toUTCString() );
-  bridge.run(port, config);
-  log.info("discordas", "Initing store.");
-  discordstore.init().then(() => {
+  bridge.run(port, config).then(() => {
+    log.info("discordas", "Initing store.");
+    return discordstore.init();
+  }).then(() => {
     log.info("discordas", "Initing bot.");
     return discordbot.run().then(() => {
       log.info("discordas", "Discordbot started successfully.");


### PR DESCRIPTION
`bridge.run` actually returns a promise that is resolved once the user and room stores have been loaded.

Not waiting for that promise before calling `discordbot.run` can sometimes (very rarely) cause one of those stores to be accessed before it is ready, crashing the AS.