### PR TITLE
HTML escape text before passing to marked

### DIFF
--- a/src/messageprocessor.ts
+++ b/src/messageprocessor.ts
@@ -42,7 +42,7 @@ export class MessageProcessor {
         content = await this.ReplaceEmoji(content, msg);
         // Replace channels
         result.body = content;
-        result.formattedBody = marked(content);
+        result.formattedBody = marked(content.replace(/&/g, "&amp;").replace(/</g, "&lt;"));
         return result;
     }
 


### PR DESCRIPTION
This prevents Matrix clients from interpreting text between angle brackets as HTML tags and thus stripping them.