### PR TITLE
Fix puppeting (get_user_discord_ids in store.ts), fix tools/addbot.ts

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -147,9 +147,7 @@ export class DiscordStore {
       },
     ).then( (rows) => {
       if (rows !== undefined) {
-        const ret = [];
-        rows.forEach((row) => ret.push(row.discord_id));
-        return ret;
+        return rows.map((row) => row.discord_id);
       } else {
         return [];
       }

--- a/src/store.ts
+++ b/src/store.ts
@@ -147,7 +147,7 @@ export class DiscordStore {
       },
     ).then( (rows) => {
       if (rows !== undefined) {
-        let ret = [];
+        const ret = [];
         rows.forEach((row) => ret.push(row.discord_id));
         return ret;
       } else {

--- a/src/store.ts
+++ b/src/store.ts
@@ -137,22 +137,24 @@ export class DiscordStore {
 
   public get_user_discord_ids(userId: string): Promise<string[]> {
     log.silly("SQL", "get_user_discord_ids => %s", userId);
-    return this.db.getAsync(
+    return this.db.allAsync(
       `
       SELECT discord_id
       FROM user_id_discord_id
-      WHERE user_id = $userId
+      WHERE user_id = $userId;
       `, {
         $userId: userId,
       },
     ).then( (rows) => {
       if (rows !== undefined) {
-        rows.map((row) => row.discord_id);
+        let ret = [];
+        rows.forEach((row) => ret.push(row.discord_id));
+        return ret;
       } else {
         return [];
       }
     }).catch( (err) => {
-      log.error("DiscordStore", "Error getting discord ids  %s", err.Error);
+      log.error("DiscordStore", "Error getting discord ids: %s", err.Error);
       throw err;
     });
   }

--- a/tools/addbot.ts
+++ b/tools/addbot.ts
@@ -21,7 +21,6 @@ const perms = flags.READ_MESSAGES |
   flags.EMBED_LINKS |
   flags.ATTACH_FILES |
   flags.READ_MESSAGE_HISTORY |
-  flags.MANAGE_MESSAGES |
   flags.MANAGE_WEBHOOKS;
 
 const url = `https://discordapp.com/api/oauth2/authorize?client_id=${clientId}&scope=bot&permissions=${perms}`;

--- a/tools/addbot.ts
+++ b/tools/addbot.ts
@@ -21,6 +21,7 @@ const perms = flags.READ_MESSAGES |
   flags.EMBED_LINKS |
   flags.ATTACH_FILES |
   flags.READ_MESSAGE_HISTORY |
+  flags.MANAGE_MESSAGES |
   flags.MANAGE_WEBHOOKS;
 
 const url = `https://discordapp.com/api/oauth2/authorize?client_id=${clientId}&scope=bot&permissions=${perms}`;


### PR DESCRIPTION
This fixes the buggy code in `src/store.ts`, making `get_user_discord_ids` actually work.

While we're at it, I also changed `tools/addbot.ts` to request the necessary permissions for delete forwarding to work properly.

*This used to be PR #65, but then I misunderstood how github works and pushed commits to the wrong branch, so you have this one now. Sorry.*