### PR TITLE
Change bot starting command to npm start

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ and synapse. Any new servers/guilds you bridge should show up in the network lis
 ### Running the Bridge
 
 * For the bot to appear online on Discord you need to run the bridge itself.
-* ``node ./build/src/discordas.js -p 9005 -c config.yaml``
+* ``npm start``
 
 [Howto](./docs/howto.md)
 


### PR DESCRIPTION
Helps to differentiate the start command and the command that generates the config. 

`npm start` also makes sure the code is up to date.