### PR TITLE
Hs/updateuser.improvements

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -53,7 +53,6 @@ export class DiscordBot {
 
   public setBridge(bridge: Bridge) {
     this.bridge = bridge;
-    this.userSync = new UserSyncroniser(this.bridge, this.config, this);
     this.mxEventProcessor = new MatrixEventProcessor(
         new MatrixEventProcessorOpts(this.config, bridge),
     );
@@ -89,6 +88,8 @@ export class DiscordBot {
           this.OnMessage(msg);
         });
       });
+      
+      this.userSync = new UserSyncroniser(this.bridge, this.config, this);
       client.on("userUpdate", (_, user) => this.userSync.OnUpdateUser(user));
       client.on("guildMemberAdd", (_, user) => this.userSync.OnAddGuildMember(user));
       client.on("guildMemberRemove", (_, user) =>  this.userSync.OnRemoveGuildMember(user));

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -321,7 +321,6 @@ export class DiscordBot {
     return dbEmoji.MxcUrl;
   }
 
-
   public GetRoomIdsFromGuild(guild: String): Promise<string[]> {
     return this.bridge.getRoomStore().getEntriesByRemoteRoomData({
       discord_guild: guild,

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -82,7 +82,7 @@ export class DiscordBot {
         client.on("presenceUpdate", (_, newMember) => { this.presenceHandler.EnqueueMember(newMember); });
       }
       client.on("channelUpdate", (_, newChannel) => { this.UpdateRooms(newChannel); });
-      client.on("messageDelete", (msg) => {this.DeleteDiscordMessage(msg); });
+      client.on("messageDelete", (msg) => { this.DeleteDiscordMessage(msg); });
       client.on("messageUpdate", (oldMessage, newMessage) => { this.OnMessageUpdate(oldMessage, newMessage); });
       client.on("message", (msg) => { Bluebird.delay(MSG_PROCESS_DELAY).then(() => {
           this.OnMessage(msg);

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -303,7 +303,7 @@ export class DiscordBot {
     return this.userSync.OnUpdateUser(null, member.user).then(() => {
       return Bluebird.each(roomIds, (roomId) => intent.join(roomId));
     }).then(() => {
-      return this.UpdateGuildMember(member, roomIds);
+      return this.userSync.OnUpdateGuildMember(member);
     });
   }
 
@@ -420,20 +420,6 @@ export class DiscordBot {
 
     // Sending was a success
     return true;
-  }
-
-  private AddGuildMember(guildMember: Discord.GuildMember) {
-    return this.GetRoomIdsFromGuild(guildMember.guild.id).then((roomIds) => {
-      return this.InitJoinUser(guildMember, roomIds);
-    });
-  }
-
-  private RemoveGuildMember(guildMember: Discord.GuildMember) {
-    const intent = this.GetIntentFromDiscordMember(guildMember);
-    return Bluebird.each(this.GetRoomIdsFromGuild(guildMember.guild.id), (roomId) => {
-        this.presenceHandler.DequeueMember(guildMember);
-        return intent.leave(roomId);
-    });
   }
 
   private UpdateGuildMember(guildMember: Discord.GuildMember, roomIds?: string[]) {

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -90,9 +90,9 @@ export class DiscordBot {
         });
       });
       client.on("userUpdate", (_, user) => this.userSync.OnUpdateUser(user));
-      client.on("guildMemberAdd", this.userSync.OnAddGuildMember);
-      client.on("guildMemberRemove", this.userSync.OnRemoveGuildMember);
-      client.on("guildMemberUpdate", this.userSync.OnUpdateGuildMember);
+      client.on("guildMemberAdd", (_, user) => this.userSync.OnAddGuildMember(user));
+      client.on("guildMemberRemove", (_, user) =>  this.userSync.OnRemoveGuildMember(user));
+      client.on("guildMemberUpdate", (oldUser, newUser) =>  this.userSync.OnUpdateGuildMember(oldUser, newUser));
       client.on("debug", (msg) => { log.verbose("discord.js", msg); });
       client.on("error", (msg) => { log.error("discord.js", msg); });
       client.on("warn", (msg) => { log.warn("discord.js", msg); });

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -84,9 +84,6 @@ export class DiscordBot {
       }
       client.on("channelUpdate", (_, newChannel) => { this.UpdateRooms(newChannel); });
       client.on("messageDelete", (msg) => {this.DeleteDiscordMessage(msg); });
-      client.on("guildMemberAdd", (newMember) => { this.AddGuildMember(newMember); });
-      client.on("guildMemberRemove", (oldMember) => { this.RemoveGuildMember(oldMember); });
-      client.on("guildMemberUpdate", (_, newMember) => { this.UpdateGuildMember(newMember); });
       client.on("messageUpdate", (oldMessage, newMessage) => { this.OnMessageUpdate(oldMessage, newMessage); });
       client.on("message", (msg) => { Bluebird.delay(MSG_PROCESS_DELAY).then(() => {
           this.OnMessage(msg);

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -57,10 +57,6 @@ export class DiscordBot {
     this.mxEventProcessor = new MatrixEventProcessor(
         new MatrixEventProcessorOpts(this.config, bridge),
     );
-    this.bot.on("userUpdate", (_, user) => this.userSync.OnUpdateUser(user));
-    this.bot.on("guildMemberAdd", this.userSync.OnAddGuildMember);
-    this.bot.on("guildMemberRemove", this.userSync.OnRemoveGuildMember);
-    this.bot.on("guildMemberUpdate", this.userSync.OnUpdateGuildMember);
   }
 
   get ClientFactory(): DiscordClientFactory {
@@ -93,6 +89,10 @@ export class DiscordBot {
           this.OnMessage(msg);
         });
       });
+      client.on("userUpdate", (_, user) => this.userSync.OnUpdateUser(user));
+      client.on("guildMemberAdd", this.userSync.OnAddGuildMember);
+      client.on("guildMemberRemove", this.userSync.OnRemoveGuildMember);
+      client.on("guildMemberUpdate", this.userSync.OnUpdateGuildMember);
       client.on("debug", (msg) => { log.verbose("discord.js", msg); });
       client.on("error", (msg) => { log.error("discord.js", msg); });
       client.on("warn", (msg) => { log.warn("discord.js", msg); });

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -91,8 +91,8 @@ export class DiscordBot {
       
       this.userSync = new UserSyncroniser(this.bridge, this.config, this);
       client.on("userUpdate", (_, user) => this.userSync.OnUpdateUser(user));
-      client.on("guildMemberAdd", (_, user) => this.userSync.OnAddGuildMember(user));
-      client.on("guildMemberRemove", (_, user) =>  this.userSync.OnRemoveGuildMember(user));
+      client.on("guildMemberAdd", (user) => this.userSync.OnAddGuildMember(user));
+      client.on("guildMemberRemove", (user) =>  this.userSync.OnRemoveGuildMember(user));
       client.on("guildMemberUpdate", (oldUser, newUser) =>  this.userSync.OnUpdateGuildMember(oldUser, newUser));
       client.on("debug", (msg) => { log.verbose("discord.js", msg); });
       client.on("error", (msg) => { log.error("discord.js", msg); });

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,21 @@ export class DiscordBridgeConfig {
   public database: DiscordBridgeConfigDatabase = new DiscordBridgeConfigDatabase();
   public room: DiscordBridgeConfigRoom = new DiscordBridgeConfigRoom();
   public limits: DiscordBridgeConfigLimits = new DiscordBridgeConfigLimits();
+
+  /**
+   * Apply a set of keys and values over the default config.
+   * @param _config Config keys
+   * @param configLayer Private parameter
+   */
+  public ApplyConfig(newConfig: {[key: string]: any}, configLayer: any = this) {
+    Object.keys(newConfig).forEach((key) => {
+      if (typeof(configLayer[key]) === "object")  {
+        this.ApplyConfig(newConfig[key], this[key]);
+        return;
+      } 
+      configLayer[key] = newConfig[key];
+    });
+  }
 }
 
 class DiscordBridgeConfigBridge {

--- a/src/discordas.ts
+++ b/src/discordas.ts
@@ -45,6 +45,7 @@ function run (port: number, config: DiscordBridgeConfig) {
   if (registration === null) {
     throw new Error("Failed to parse registration file");
   }
+  config = Object.assign({}, new DiscordBridgeConfig(), config);
   const botUserId = "@" + registration.sender_localpart + ":" + config.bridge.domain;
   const clientFactory = new ClientFactory({
     appServiceUserId: botUserId,

--- a/src/discordas.ts
+++ b/src/discordas.ts
@@ -37,7 +37,9 @@ function generateRegistration(reg, callback)  {
   callback(reg);
 }
 
-function run (port: number, config: DiscordBridgeConfig) {
+function run (port: number, fileConfig: DiscordBridgeConfig) {
+  const config = new DiscordBridgeConfig();
+  config.ApplyConfig(fileConfig);
   log.level = config.logging ? (config.logging.level || "warn") : "warn";
   log.info("discordas", "Starting Discord AS");
   const yamlConfig = yaml.safeLoad(fs.readFileSync("discord-registration.yaml", "utf8"));
@@ -45,7 +47,7 @@ function run (port: number, config: DiscordBridgeConfig) {
   if (registration === null) {
     throw new Error("Failed to parse registration file");
   }
-  config = Object.assign({}, new DiscordBridgeConfig(), config);
+
   const botUserId = "@" + registration.sender_localpart + ":" + config.bridge.domain;
   const clientFactory = new ClientFactory({
     appServiceUserId: botUserId,

--- a/src/matrixroomhandler.ts
+++ b/src/matrixroomhandler.ts
@@ -89,7 +89,9 @@ export class MatrixRoomHandler {
       return Promise.reject("Event too old");
     }
     if (event.type === "m.room.member" && event.content.membership === "invite") {
-      return this.HandleInvite(event);
+        return this.HandleInvite(event);
+    } else if (event.type === "m.room.member" && event.content.membership === "join") {
+        // Potentially this means a AS user has
     } else if (event.type === "m.room.redaction" && context.rooms.remote) {
       return this.discord.ProcessMatrixRedact(event);
     } else if (event.type === "m.room.message") {

--- a/src/matrixroomhandler.ts
+++ b/src/matrixroomhandler.ts
@@ -22,6 +22,7 @@ const ROOM_NAME_PARTS = 2;
 const AGE_LIMIT = 900000; // 15 * 60 * 1000
 const PROVISIONING_DEFAULT_POWER_LEVEL = 50;
 const PROVISIONING_DEFAULT_USER_POWER_LEVEL = 0;
+const USERSYNC_STATE_DELAY_MS = 5000;
 
 // Note: The schedule must not have duplicate values to avoid problems in positioning.
 /* tslint:disable:no-magic-numbers */ // Disabled because it complains about the values in the array
@@ -63,23 +64,24 @@ export class MatrixRoomHandler {
 
   public OnAliasQueried (alias: string, roomId: string) {
     // Join a whole bunch of users.
-    let promiseChain: any = Bluebird.resolve();
+    // TODO: Make UserSync do this!
+    // let promiseChain: any = Bluebird.resolve();
     /* We delay the joins to give some implementations a chance to breathe */
-    let delay = this.config.limits.roomGhostJoinDelay;
-    return this.discord.GetChannelFromRoomId(roomId).then((channel: Discord.Channel) => {
-      for (const member of (<Discord.TextChannel> channel).members.array()) {
-        if (member.id === this.discord.GetBotId()) {
-          continue;
-        }
-        promiseChain = promiseChain.return(Bluebird.delay(delay).then(() => {
-          return this.discord.InitJoinUser(member, [roomId]);
-        }));
-        delay += this.config.limits.roomGhostJoinDelay;
-      }
-    }).catch((err) => {
-      log.verbose("OnAliasQueried => %s", err);
-      throw err;
-    });
+    // let delay = this.config.limits.roomGhostJoinDelay;
+    // return this.discord.GetChannelFromRoomId(roomId).then((channel: Discord.Channel) => {
+    //   for (const member of (<Discord.TextChannel> channel).members.array()) {
+    //     if (member.id === this.discord.GetBotId()) {
+    //       continue;
+    //     }
+    //     promiseChain = promiseChain.return(Bluebird.delay(delay).then(() => {
+    //       return this.discord.InitJoinUser(member, [roomId]);
+    //     }));
+    //     delay += this.config.limits.roomGhostJoinDelay;
+    //   }
+    // }).catch((err) => {
+    //   log.verbose("OnAliasQueried => %s", err);
+    //   throw err;
+    // });
   }
 
   public OnEvent (request, context): Promise<any> {

--- a/src/matrixroomhandler.ts
+++ b/src/matrixroomhandler.ts
@@ -87,7 +87,7 @@ export class MatrixRoomHandler {
             return this.discord.UserSyncroniser.OnUpdateUser(member.user);
         }).then(() => {
             log.info("OnAliasQueried", `Joining ${member.id} to ${roomId}`);
-            return this.discord.GetIntentFromDiscordMember(member).join(roomId);
+            return this.joinRoom(this.discord.GetIntentFromDiscordMember(member), roomId);
         }));
         delay += this.config.limits.roomGhostJoinDelay;
     }

--- a/src/matrixroomhandler.ts
+++ b/src/matrixroomhandler.ts
@@ -93,7 +93,9 @@ export class MatrixRoomHandler {
     if (event.type === "m.room.member" && event.content.membership === "invite") {
         return this.HandleInvite(event);
     } else if (event.type === "m.room.member" && event.content.membership === "join") {
-        // Potentially this means a AS user has
+        if (this.bridge.getBot()._isRemoteUser(event.state_key)) {
+            return this.discord.UserSyncroniser.OnMemberState(event, USERSYNC_STATE_DELAY_MS);
+        }
     } else if (event.type === "m.room.redaction" && context.rooms.remote) {
       return this.discord.ProcessMatrixRedact(event);
     } else if (event.type === "m.room.message") {

--- a/src/matrixroomhandler.ts
+++ b/src/matrixroomhandler.ts
@@ -91,6 +91,7 @@ export class MatrixRoomHandler {
         }));
         delay += this.config.limits.roomGhostJoinDelay;
     }
+    // tslint:disable-next-line:await-promise
     await promiseChain;
   }
 

--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -1,0 +1,135 @@
+import { User, GuildMember } from "discord.js";
+import * as log from "npmlog";
+import { DiscordBot } from "./bot";
+import {Util} from "./util";
+import { MatrixUser, RemoteUser, Bridge, Entry } from "matrix-appservice-bridge";
+import {DiscordBridgeConfig} from "./config";
+
+const DEFAULT_USER_STATE = {
+    id: null,
+    createUser: false,
+    mxUserId: null,
+    displayName: null, // Nullable
+    avatarUrl: null, // Nullable
+    avatarId: null,
+    removeAvatar: false,
+};
+
+export interface IUserState {
+    id: string;
+    createUser: boolean;
+    mxUserId: string;
+    displayName: string; // Nullable
+    avatarUrl: string; // Nullable
+    avatarId: string;
+    removeAvatar: boolean; // If the avatar has been removed from the user.
+}
+
+/**
+ * Class that syncronises Discord users with their bridge ghost counterparts.
+ * Also handles member events that may occur when using guild nicknames.
+ */
+export class UserSyncroniser {
+
+    constructor(private bridge: Bridge, private config: DiscordBridgeConfig) { }
+
+    public async OnUpdateUser(oldUser: User, newUser: User) {
+        const userState: IUserState = await this.GetUserUpdateState(oldUser, newUser);
+        this.ApplyUserState(userState);
+    }
+
+    public async ApplyUserState(userState: IUserState) {
+        const intent = this.bridge.getIntent(userState.mxUserId);
+        const userStore = this.bridge.getUserStore();
+        let userUpdated = false;
+        let remoteUser = null;
+        if (userState.createUser) {
+            log.info(`Creating new user ${userState.mxUserId}`);
+            remoteUser = new RemoteUser(userState.id);
+            await userStore.linkUsers(
+                new MatrixUser(userState.mxUserId.substr("@".length)),
+                remoteUser,
+            );
+        } else {
+            remoteUser = await userStore.GetRemoteUser(userState.id);
+        }
+
+        if (userState.displayName !== null) {
+            log.verbose(`Updating displayname for ${userState.mxUserId} to "${userState.displayName}"`);
+            await intent.setDisplayName(userState.displayName);
+            remoteUser.set("displayname", userState.displayName);
+            userUpdated = true;
+        }
+
+        if (userState.avatarUrl !== null) {
+            log.verbose(`Updating avatar_url for ${userState.mxUserId} to "${userState.avatarUrl}"`);
+            const avatarMxc = await Util.UploadContentFromUrl(
+                userState.avatarUrl,
+                intent,
+                userState.avatarId,
+            );
+            await intent.setAvatar(avatarMxc.mxcUrl);
+            remoteUser.set("avatarurl", userState.avatarUrl);
+            userUpdated = true;
+        }
+
+        if (userUpdated) {
+            userStore.setRemoteUser(remoteUser);
+            // NOTE: We've updated the *main* profile, which means we need to redo nicknames.
+        }
+    }
+
+    public async GetUserUpdateState(oldUser: User, newUser?: User): Promise<IUserState> {
+        if (newUser === null) {
+            newUser = oldUser;
+        }
+        log.verbose("UserSync", `State update requested for ${newUser.id}`);
+        const userState = Object.assign({}, DEFAULT_USER_STATE);
+        userState.id = newUser.id;
+        const displayName = newUser.username + "#" + newUser.discriminator;
+        userState.mxUserId = `@_discord_${newUser.id}:${this.config.bridge.domain}`;
+        const userStore = this.bridge.getUserStore();
+        // Determine if the user exists.
+        const remoteUser = await userStore.getRemoteUser(newUser.id);
+
+        if (remoteUser === null) {
+            log.verbose("UserSync", `Could not find user in remote user store.`);
+            userState.createUser = true;
+            userState.displayName = displayName;
+            userState.avatarUrl = newUser.avatarURL;
+            userState.avatarId = "111";
+            return userState;
+        }
+
+        const oldDisplayName = remoteUser.get("displayname");
+        if (oldDisplayName !== displayName) {
+            log.verbose("UserSync", `User ${newUser.id} displayname should be updated`);
+            userState.displayName = displayName;
+        }
+
+        const oldAvatarUrl = remoteUser.get("avatarurl");
+        if (oldAvatarUrl !== newUser.avatarURL) {
+            log.verbose("UserSync", `User ${newUser.id} avatarurl should be updated`);
+            if (newUser.avatarURL !== null) {
+                userState.avatarUrl = newUser.avatarURL;
+                userState.avatarId = newUser.avatar;
+            } else {
+                userState.removeAvatar = oldAvatarUrl !== null;
+            }
+        }
+
+        return userState;
+    }
+
+    public OnAddGuildMember(member: GuildMember) {
+
+    }
+
+    public OnRemoveGuildMember(member: GuildMember) {
+
+    }
+
+    public OnUpdateGuildMember(oldMember: GuildMember, newMember: GuildMember) {
+
+    }
+}

--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -50,8 +50,9 @@ export class UserSyncroniser {
                 new MatrixUser(userState.mxUserId.substr("@".length)),
                 remoteUser,
             );
+
         } else {
-            remoteUser = await userStore.GetRemoteUser(userState.id);
+            remoteUser = await userStore.getRemoteUser(userState.id);
         }
 
         if (userState.displayName !== null) {
@@ -68,8 +69,14 @@ export class UserSyncroniser {
                 intent,
                 userState.avatarId,
             );
-            await intent.setAvatar(avatarMxc.mxcUrl);
+            await intent.setAvatarUrl(avatarMxc.mxcUrl);
             remoteUser.set("avatarurl", userState.avatarUrl);
+            userUpdated = true;
+        }
+
+        if (userState.removeAvatar) {
+            await intent.setAvatarUrl(null);
+            remoteUser.set("avatarurl", null);
             userUpdated = true;
         }
 

--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -1,9 +1,10 @@
-import { User, GuildMember } from "discord.js";
+import {User, GuildMember, GuildChannel} from "discord.js";
 import * as log from "npmlog";
 import { DiscordBot } from "./bot";
 import {Util} from "./util";
-import { MatrixUser, RemoteUser, Bridge, Entry } from "matrix-appservice-bridge";
+import { MatrixUser, RemoteUser, Bridge, Entry, UserBridgeStore } from "matrix-appservice-bridge";
 import {DiscordBridgeConfig} from "./config";
+import * as Bluebird from "bluebird";
 
 const DEFAULT_USER_STATE = {
     id: null,
@@ -15,6 +16,12 @@ const DEFAULT_USER_STATE = {
     removeAvatar: false,
 };
 
+const DEFAULT_GUILD_STATE = {
+    id: null,
+    mxUserId: null,
+    displayName: null,
+};
+
 export interface IUserState {
     id: string;
     createUser: boolean;
@@ -23,6 +30,12 @@ export interface IUserState {
     avatarUrl: string; // Nullable
     avatarId: string;
     removeAvatar: boolean; // If the avatar has been removed from the user.
+};
+
+export interface IGuildMemberState {
+    id: string;
+    mxUserId: string;
+    displayName: string;
 }
 
 /**
@@ -30,40 +43,58 @@ export interface IUserState {
  * Also handles member events that may occur when using guild nicknames.
  */
 export class UserSyncroniser {
-
-    constructor(private bridge: Bridge, private config: DiscordBridgeConfig) { }
-
-    public async OnUpdateUser(oldUser: User, newUser: User) {
-        const userState: IUserState = await this.GetUserUpdateState(oldUser, newUser);
-        this.ApplyUserState(userState);
+    // roomId+userId => ev
+    public userStateHold: Map<string, any>;
+    private userStore: UserBridgeStore;
+    constructor(
+        private bridge: Bridge,
+        private config: DiscordBridgeConfig,
+        private discord: DiscordBot) {
+        this.userStore = this.bridge.getUserStore();
+        this.userStateHold = new Map<string, any>();
     }
 
-    public async ApplyUserState(userState: IUserState) {
+    /**
+     * Should be called when the discord user is updated.
+     * @param {module:discord.js.User} Old user object. If not used, new user object.
+     * @param {module:discord.js.User} New user object
+     * @returns {Promise<void>}
+     * @constructor
+     */
+    public async OnUpdateUser(discordUser: User) {
+        const userState = await this.GetUserUpdateState(discordUser);
+        try {
+            await this.ApplyStateToProfile(userState);
+        } catch(e) {
+            log.error("UserSync", "Failed to update user's profile", e);
+        }
+    }
+
+    public async ApplyStateToProfile(userState: IUserState) {
         const intent = this.bridge.getIntent(userState.mxUserId);
-        const userStore = this.bridge.getUserStore();
         let userUpdated = false;
         let remoteUser = null;
         if (userState.createUser) {
             log.info(`Creating new user ${userState.mxUserId}`);
             remoteUser = new RemoteUser(userState.id);
-            await userStore.linkUsers(
+            await this.userStore.linkUsers(
                 new MatrixUser(userState.mxUserId.substr("@".length)),
                 remoteUser,
             );
 
         } else {
-            remoteUser = await userStore.getRemoteUser(userState.id);
+            remoteUser = await this.userStore.getRemoteUser(userState.id);
         }
 
         if (userState.displayName !== null) {
-            log.verbose(`Updating displayname for ${userState.mxUserId} to "${userState.displayName}"`);
+            log.verbose("UserSync", `Updating displayname for ${userState.mxUserId} to "${userState.displayName}"`);
             await intent.setDisplayName(userState.displayName);
             remoteUser.set("displayname", userState.displayName);
             userUpdated = true;
         }
 
         if (userState.avatarUrl !== null) {
-            log.verbose(`Updating avatar_url for ${userState.mxUserId} to "${userState.avatarUrl}"`);
+            log.verbose("UserSync", `Updating avatar_url for ${userState.mxUserId} to "${userState.avatarUrl}"`);
             const avatarMxc = await Util.UploadContentFromUrl(
                 userState.avatarUrl,
                 intent,
@@ -75,51 +106,65 @@ export class UserSyncroniser {
         }
 
         if (userState.removeAvatar) {
+            log.verbose("UserSync", `Clearing avatar_url for ${userState.mxUserId} to "${userState.avatarUrl}"`);
             await intent.setAvatarUrl(null);
             remoteUser.set("avatarurl", null);
             userUpdated = true;
         }
 
         if (userUpdated) {
-            userStore.setRemoteUser(remoteUser);
-            // NOTE: We've updated the *main* profile, which means we need to redo nicknames.
+            await this.userStore.setRemoteUser(remoteUser);
         }
     }
 
-    public async GetUserUpdateState(oldUser: User, newUser?: User): Promise<IUserState> {
-        if (newUser === null) {
-            newUser = oldUser;
+    public async ApplyStateToRoom(memberState: IGuildMemberState, roomId: string, guildId: string) {
+        if (memberState.displayName === null) {
+            // Nothing to do. Quitting
+            return;
         }
-        log.verbose("UserSync", `State update requested for ${newUser.id}`);
-        const userState = Object.assign({}, DEFAULT_USER_STATE);
-        userState.id = newUser.id;
-        const displayName = newUser.username + "#" + newUser.discriminator;
-        userState.mxUserId = `@_discord_${newUser.id}:${this.config.bridge.domain}`;
-        const userStore = this.bridge.getUserStore();
-        // Determine if the user exists.
-        const remoteUser = await userStore.getRemoteUser(newUser.id);
+        const nickKey = `nick_${guildId}`;
+        const remoteUser = await this.userStore.getRemoteUser(memberState.id);
+        const intent = this.bridge.getIntent(memberState.mxUserId);
 
+        await intent.sendStateEvent(roomId, "m.room.member", {
+            membership: "join",
+            avatar_url: remoteUser.get("avatarurl"),
+            displayname: memberState.displayName,
+        }, memberState.mxUserId);
+        remoteUser.set(nickKey, memberState.displayName);
+        return this.userStore.setRemoteUser(remoteUser);
+    }
+
+    public async GetUserUpdateState(discordUser: User): Promise<IUserState> {
+        log.verbose("UserSync", `State update requested for ${discordUser.id}`);
+        const userState = Object.assign({}, DEFAULT_USER_STATE, {
+            id: discordUser.id,
+            mxUserId: `@_discord_${discordUser.id}:${this.config.bridge.domain}`,
+        });
+        const displayName = this.displayNameForUser(discordUser);
+        // Determine if the user exists.
+        const remoteUser = await this.userStore.getRemoteUser(discordUser.id);
         if (remoteUser === null) {
             log.verbose("UserSync", `Could not find user in remote user store.`);
             userState.createUser = true;
             userState.displayName = displayName;
-            userState.avatarUrl = newUser.avatarURL;
-            userState.avatarId = "111";
+            userState.avatarUrl = discordUser.avatarURL;
+            userState.avatarId = discordUser.avatar;
             return userState;
         }
 
         const oldDisplayName = remoteUser.get("displayname");
         if (oldDisplayName !== displayName) {
-            log.verbose("UserSync", `User ${newUser.id} displayname should be updated`);
+            log.verbose("UserSync", `User ${discordUser.id} displayname should be updated`);
             userState.displayName = displayName;
         }
 
         const oldAvatarUrl = remoteUser.get("avatarurl");
-        if (oldAvatarUrl !== newUser.avatarURL) {
-            log.verbose("UserSync", `User ${newUser.id} avatarurl should be updated`);
-            if (newUser.avatarURL !== null) {
-                userState.avatarUrl = newUser.avatarURL;
-                userState.avatarId = newUser.avatar;
+        if (oldAvatarUrl !== discordUser.avatarURL) {
+            log.verbose("UserSync", `User ${discordUser.id} avatarurl should be updated`);
+            if (discordUser.avatarURL !== null) {
+                userState.avatarUrl = discordUser.avatarURL;
+                userState.avatarId = discordUser.avatar;
             } else {
                 userState.removeAvatar = oldAvatarUrl !== null;
             }
@@ -128,17 +173,109 @@ export class UserSyncroniser {
         return userState;
     }
 
-    public OnAddGuildMember(member: GuildMember) {
+    public async GetUserStateForGuildMember(
+        newMember: GuildMember,
+        displayname: string,
+    ): Promise<IGuildMemberState> {
+        const nickKey = `nick_${newMember.guild.id}`;
+        const guildState = Object.assign({}, DEFAULT_GUILD_STATE, {
+            id: newMember.id,
+            mxUserId: `@_discord_${newMember.id}:${this.config.bridge.domain}`,
+        });
 
-    }
-
-    public OnRemoveGuildMember(member: GuildMember) {
-
-    }
-
-    public OnUpdateGuildMember(oldMember: GuildMember, newMember: GuildMember = null) {
-        if (newMember === null) {
-            newMember = oldMember;
+        // Check guild nick.
+        if (displayname !== newMember.displayName) {
+            guildState.displayName = newMember.displayName;
         }
+        return guildState;
+    }
+
+    public async OnAddGuildMember(member: GuildMember) {
+        log.info("UserSync", `Joining ${member.id} to all rooms for guild ${member.guild.id}`);
+        const rooms = await this.discord.GetRoomIdsFromGuild(member.guild.id);
+        const intent = this.discord.GetIntentFromDiscordMember(member);
+        await this.OnUpdateUser(member.user);
+        await Promise.all(
+            rooms.map(
+                (roomId) => intent.join(roomId),
+            ),
+        );
+        ;
+    }
+
+    public async OnRemoveGuildMember(member: GuildMember) {
+        log.info("UserSync", `Leaving ${member.id} to all rooms for guild ${member.guild.id}`);
+        const rooms = await this.discord.GetRoomIdsFromGuild(member.guild.id);
+        const intent = this.discord.GetIntentFromDiscordMember(member);
+        return Promise.all(
+            rooms.map(
+                (roomId) => intent.leave(roomId),
+            ),
+        );
+    }
+
+    public async OnUpdateGuildMember(oldMember: GuildMember, newMember: GuildMember) {
+        const state = await this.GetUserStateForGuildMember(newMember, oldMember.displayName);
+        const rooms = await this.discord.GetRoomIdsFromGuild(newMember.guild.id);
+        return Promise.all(
+            rooms.map(
+                (roomId) => this.ApplyStateToRoom(state, roomId, newMember.guild.id),
+            ),
+        );
+    }
+
+    public async OnMemberState(ev: any, delayMs: number = 0) {
+        // Avoid tripping over multiple state events.
+        if (await this.memberStateLock(ev, delayMs) === false) {
+            // We're igorning this update because we have a newer one.
+            return;
+        }
+        log.verbose("UserSync", `m.room.member was updated for ${ev.state_key}, checking if nickname needs updating.`);
+        const roomId = ev.room_id;
+        let discordId;
+        try {
+            const remoteUsers = await this.userStore.getRemoteUsersFromMatrixId(ev.state_key);
+            if (remoteUsers.length === 0) {
+                throw Error("User not found");
+            }
+            discordId = remoteUsers[0].getId();
+        } catch (e) {
+            log.warn("UserSync", `Got member update for ${ev.state_key}, but no user is linked in the store`);
+            return;
+        }
+
+        // Fetch guild member by roomId;
+        let member;
+        try {
+            const channel = await this.discord.GetChannelFromRoomId(roomId) as GuildChannel;
+            member = channel.guild.fetchMember(discordId);
+        } catch (e) {
+            log.warn("UserSync", `Got member update for ${roomId}, but no channel was associated with it`);
+            return;
+        }
+        const state = await this.GetUserStateForGuildMember(member, ev.content.displayname);
+        return this.ApplyStateToRoom(state, roomId, member.guild.id);
+    }
+
+    private async memberStateLock(ev: any, delayMs: number = -1): Promise<boolean> {
+        const userStateKey = `${ev.room_id}${ev.state_key}`;
+        if (this.userStateHold.has(userStateKey)) {
+            const oldEv = this.userStateHold.get(userStateKey);
+            if (ev.origin_server_ts < oldEv.origin_server_ts) {
+                return false; // New event is older
+            }
+        }
+        this.userStateHold.set(userStateKey, ev);
+        await Bluebird.delay(delayMs);
+        if (this.userStateHold.get(userStateKey).event_id !== ev.event_id) {
+            // Event has changed and we are out of date.
+            return false;
+        }
+        this.userStateHold.delete(userStateKey);
+        return true;
+    }
+
+    private displayNameForUser(discordUser): string {
+        return discordUser.username + "#" + discordUser.discriminator;
     }
 }

--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -108,6 +108,7 @@ export class UserSyncroniser {
             );
             await intent.setAvatarUrl(avatarMxc.mxcUrl);
             remoteUser.set("avatarurl", userState.avatarUrl);
+            remoteUser.set("avatarurl_mxc", avatarMxc.mxcUrl);
             userUpdated = true;
         }
 
@@ -115,6 +116,7 @@ export class UserSyncroniser {
             log.verbose("UserSync", `Clearing avatar_url for ${userState.mxUserId} to "${userState.avatarUrl}"`);
             await intent.setAvatarUrl(null);
             remoteUser.set("avatarurl", null);
+            remoteUser.set("avatarurl_mxc", null);
             userUpdated = true;
         }
 
@@ -135,7 +137,7 @@ export class UserSyncroniser {
         log.verbose("UserSync", `Sending state event for state ${JSON.stringify(memberState)}.`);
         await intent.sendStateEvent(roomId, "m.room.member", memberState.mxUserId, {
             membership: "join",
-            avatar_url: remoteUser.get("avatarurl"),
+            avatar_url: remoteUser.get("avatarurl_mxc"),
             displayname: memberState.displayName,
         });
         remoteUser.set(nickKey, memberState.displayName);

--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -70,7 +70,7 @@ export class UserSyncroniser {
         const userState = await this.GetUserUpdateState(discordUser);
         try {
             await this.ApplyStateToProfile(userState);
-        } catch(e) {
+        } catch (e) {
             log.error("UserSync", "Failed to update user's profile", e);
         }
     }
@@ -273,6 +273,7 @@ export class UserSyncroniser {
             }
         }
         this.userStateHold.set(userStateKey, ev);
+        // tslint:disable-next-line:await-promise
         await Bluebird.delay(delayMs);
         if (this.userStateHold.get(userStateKey).event_id !== ev.event_id) {
             // Event has changed and we are out of date.

--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -80,6 +80,7 @@ export class UserSyncroniser {
         let userUpdated = false;
         let remoteUser = null;
         if (userState.createUser) {
+            /* NOTE: Setting the displayname/avatar will register the user if they don't exist */
             log.info(`Creating new user ${userState.mxUserId}`);
             remoteUser = new RemoteUser(userState.id);
             await this.userStore.linkUsers(

--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -136,7 +136,9 @@ export class UserSyncroniser {
 
     }
 
-    public OnUpdateGuildMember(oldMember: GuildMember, newMember: GuildMember) {
-
+    public OnUpdateGuildMember(oldMember: GuildMember, newMember: GuildMember = null) {
+        if (newMember === null) {
+            newMember = oldMember;
+        }
     }
 }

--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -183,7 +183,6 @@ export class UserSyncroniser {
         newMember: GuildMember,
         displayname: string,
     ): Promise<IGuildMemberState> {
-        const nickKey = `nick_${newMember.guild.id}`;
         const guildState = Object.assign({}, DEFAULT_GUILD_STATE, {
             id: newMember.id,
             mxUserId: `@_discord_${newMember.id}:${this.config.bridge.domain}`,

--- a/test/mocks/guild.ts
+++ b/test/mocks/guild.ts
@@ -17,6 +17,13 @@ export class MockGuild {
     });
   }
 
+  public fetchMember(id: string): Promise<MockMember|Error>{
+    if (this.members.has(id)) {
+      return Promise.resolve(this.members.get(id));
+    }
+    return Promise.reject("Member not in this guild");
+  }
+
   public _mockAddMember(member: MockMember) {
       this.members.set(member.id, member);
   }

--- a/test/mocks/guild.ts
+++ b/test/mocks/guild.ts
@@ -17,7 +17,7 @@ export class MockGuild {
     });
   }
 
-  public fetchMember(id: string): Promise<MockMember|Error>{
+  public fetchMember(id: string): Promise<MockMember|Error> {
     if (this.members.has(id)) {
       return Promise.resolve(this.members.get(id));
     }

--- a/test/mocks/member.ts
+++ b/test/mocks/member.ts
@@ -5,12 +5,10 @@ export class MockMember {
   public id = "";
   public presence: Discord.Presence;
   public user: MockUser;
-  public displayName: string;
-  constructor(id: string, username: string) {
+  constructor(id: string, username: string, public guild = null, public displayName: string = username) {
     this.id = id;
     this.presence = new Discord.Presence({});
     this.user = new MockUser(this.id, username);
-    this.displayName = username;
   }
 
   public MockSetPresence(presence: Discord.Presence) {

--- a/test/mocks/user.ts
+++ b/test/mocks/user.ts
@@ -1,9 +1,9 @@
 export class MockUser {
-  public id = "";
-  public username: string;
-  public discriminator: string;
-  constructor(id: string, username: string = "") {
-    this.id = id;
-    this.username = username;
-  }
+  constructor(
+      public id: string,
+      public username: string = "",
+      public discriminator: string = "",
+      public avatarURL: string = "",
+      public avatar: string = "",
+  ) { }
 }

--- a/test/test_discordbot.ts
+++ b/test/test_discordbot.ts
@@ -36,6 +36,9 @@ const mockBridge = {
       },
     };
   },
+  getUserStore: () => {
+    return {};
+  },
 };
 
 const modDiscordBot = Proxyquire("../src/bot", {
@@ -55,8 +58,9 @@ describe("DiscordBot", () => {
     it("should resolve when ready.", () => {
       discordBot = new modDiscordBot.DiscordBot(
         config,
-        mockBridge,
+        null,
       );
+      discordBot.setBridge(mockBridge);
       return discordBot.run();
     });
   });
@@ -65,8 +69,9 @@ describe("DiscordBot", () => {
     beforeEach(() => {
       discordBot = new modDiscordBot.DiscordBot(
         config,
-        mockBridge,
+        null,
       );
+      discordBot.setBridge(mockBridge);
       return discordBot.run();
     });
     it("should reject a missing guild.", () => {

--- a/test/test_matrixroomhandler.ts
+++ b/test/test_matrixroomhandler.ts
@@ -111,28 +111,28 @@ function createRH(opts: any = {}) {
 }
 
 describe("MatrixRoomHandler", () => {
-    describe("OnAliasQueried", () => {
-        it("should join successfully", () => {
-            const handler = createRH();
-            return expect(handler.OnAliasQueried("#accept:localhost", "!accept:localhost")).to.be.fulfilled;
-        });
-        it("should join successfully and create ghosts", () => {
-            const EXPECTEDUSERS = 2;
-            const TESTDELAY = 50;
-            const handler = createRH({createMembers: true});
-            return  handler.OnAliasQueried("#accept:localhost", "!accept:localhost").then(() => {
-                return Bluebird.delay(TESTDELAY);
-            }).then(() => {
-                    expect(USERSJOINED).to.equal(EXPECTEDUSERS);
-                    // test for something
-                    return true;
-            });
-        });
-        it("should not join successfully", () => {
-            const handler = createRH();
-            return expect(handler.OnAliasQueried("#reject:localhost", "!reject:localhost")).to.be.rejected;
-        });
-    });
+    // describe("OnAliasQueried", () => {
+    //     it("should join successfully", () => {
+    //         const handler = createRH();
+    //         return expect(handler.OnAliasQueried("#accept:localhost", "!accept:localhost")).to.be.fulfilled;
+    //     });
+    //     it("should join successfully and create ghosts", () => {
+    //         const EXPECTEDUSERS = 2;
+    //         const TESTDELAY = 50;
+    //         const handler = createRH({createMembers: true});
+    //         return  handler.OnAliasQueried("#accept:localhost", "!accept:localhost").then(() => {
+    //             return Bluebird.delay(TESTDELAY);
+    //         }).then(() => {
+    //                 expect(USERSJOINED).to.equal(EXPECTEDUSERS);
+    //                 // test for something
+    //                 return true;
+    //         });
+    //     });
+    //     it("should not join successfully", () => {
+    //         const handler = createRH();
+    //         return expect(handler.OnAliasQueried("#reject:localhost", "!reject:localhost")).to.be.rejected;
+    //     });
+    // });
     describe("OnEvent", () => {
         it("should reject old events", () => {
             const AGE = 900001; // 15 * 60 * 1000

--- a/test/test_matrixroomhandler.ts
+++ b/test/test_matrixroomhandler.ts
@@ -107,6 +107,10 @@ function createRH(opts: any = {}) {
         config.bridge.enableSelfServiceBridging = true;
     }
     const mxClient = {
+        joinRoom: () => {
+            USERSJOINED++;
+            return Promise.resolve();
+        },
         getStateEvent: () => {
             return Promise.resolve(opts.powerLevels || {});
         },
@@ -142,14 +146,9 @@ describe("MatrixRoomHandler", () => {
         });
         it("should join successfully and create ghosts", () => {
             const EXPECTEDUSERS = 2;
-            const TESTDELAY = 50;
             const handler = createRH({createMembers: true});
-            return  handler.OnAliasQueried("#accept:localhost", "!accept:localhost").then(() => {
-                return Bluebird.delay(TESTDELAY);
-            }).then(() => {
-                    expect(USERSJOINED).to.equal(EXPECTEDUSERS);
-                    // test for something
-                    return true;
+            return handler.OnAliasQueried("#accept:localhost", "!accept:localhost").then(() => {
+                expect(USERSJOINED).to.equal(EXPECTEDUSERS);
             });
         });
         it("should not join successfully", () => {

--- a/test/test_matrixroomhandler.ts
+++ b/test/test_matrixroomhandler.ts
@@ -52,10 +52,10 @@ function createRH(opts: any = {}) {
         },
         getRoomStore: () => {
             return {
-                removeEntriesByMatrixRoomId:() => {
+                removeEntriesByMatrixRoomId: () => {
 
-                }
-            }
+                },
+            };
         },
     };
     const us = {

--- a/test/test_matrixroomhandler.ts
+++ b/test/test_matrixroomhandler.ts
@@ -39,15 +39,16 @@ function createRH(opts: any = {}) {
             return {
                 sendMessage: (roomId, content) => Promise.resolve(content),
                 getClient: () => mxClient,
-                join: () => { USERSJOINED++ },
-        }; },
+                join: () => { USERSJOINED++; },
+            }; 
+        },
         getBot: () => {
             return {
                 _isRemoteUser: (id) => {
                     return id !== undefined && id.startsWith("@_discord_");
                 },
             };
-        }
+        },
     };
     const us = {
         OnMemberState: () => Promise.resolve("user_sync_handled"),

--- a/test/test_matrixroomhandler.ts
+++ b/test/test_matrixroomhandler.ts
@@ -40,6 +40,7 @@ function createRH(opts: any = {}) {
                 sendMessage: (roomId, content) => Promise.resolve(content),
                 getClient: () => mxClient,
                 join: () => { USERSJOINED++; },
+                leave: () => { },
             }; 
         },
         getBot: () => {
@@ -49,6 +50,13 @@ function createRH(opts: any = {}) {
                 },
             };
         },
+        getRoomStore: () => {
+            return {
+                removeEntriesByMatrixRoomId:() => {
+
+                }
+            }
+        },
     };
     const us = {
         OnMemberState: () => Promise.resolve("user_sync_handled"),
@@ -57,12 +65,14 @@ function createRH(opts: any = {}) {
     const bot = {
         GetChannelFromRoomId: (roomid: string) => {
             if (roomid === "!accept:localhost") {
-                const chan = new MockChannel();
+                const guild = new MockGuild("666666");
+                const chan = new MockChannel("777777", guild);
                 if (opts.createMembers) {
                     chan.members.set("12345", new MockMember("12345", "testuser1"));
                     chan.members.set("54321", new MockMember("54321", "testuser2"));
                     chan.members.set("bot12345", new MockMember("bot12345", "botuser"));
                 }
+                guild.members = chan.members;
                 return Promise.resolve(chan);
             } else {
                 return Promise.reject("Roomid not found");

--- a/test/test_messageprocessor.ts
+++ b/test/test_messageprocessor.ts
@@ -1,20 +1,13 @@
 import * as Chai from "chai";
 import * as ChaiAsPromised from "chai-as-promised";
-import * as log from "npmlog";
 import * as Discord from "discord.js";
-import * as Proxyquire from "proxyquire";
-
-// import * as Proxyquire from "proxyquire";
 import { MessageProcessor, MessageProcessorOpts } from "../src/messageprocessor";
 import { DiscordBot } from "../src/bot";
 import { MockGuild } from "./mocks/guild";
 import { MockMember } from "./mocks/member";
 
 Chai.use(ChaiAsPromised);
-const expect = Chai.expect;
-log.level = "silly";
 
-// const assert = Chai.assert;
 const bot = {
     GetEmoji: (name: string, animated: boolean, id: string): Promise<string> => {
         if (id === "3333333") {

--- a/test/test_usersyncroniser.ts
+++ b/test/test_usersyncroniser.ts
@@ -135,7 +135,7 @@ function CreateUserSync(remoteUsers: any[] = []): UserSyncroniser {
 
 describe("UserSyncroniser", () => {
    describe("GetUserUpdateState", () => {
-       it("Will create new users", () => {
+       it("Will create a new user", () => {
            const userSync = CreateUserSync();
            const user = new MockUser(
                "123456",
@@ -306,7 +306,7 @@ describe("UserSyncroniser", () => {
                expect(DISPLAYNAME_SET).is.null;
            });
        });
-       it("Will fetch an existing user", () => {
+       it("will do nothing if nothing needs to be done", () => {
            const userSync = CreateUserSync([new RemoteUser("123456")]);
            const state: IUserState = {
                id: "123456",

--- a/test/test_usersyncroniser.ts
+++ b/test/test_usersyncroniser.ts
@@ -29,6 +29,7 @@ const UserSync = (Proxyquire("../src/usersyncroniser", {
 })).UserSyncroniser;
 
 function CreateUserSync(remoteUsers: any[] = []): UserSyncroniser {
+    UTIL_UPLOADED_AVATAR = false;
     const bridge: any = {
         getUserStore: () => {
             REMOTEUSER_SET = null;
@@ -220,6 +221,28 @@ describe("UserSyncroniser", () => {
                expect(UTIL_UPLOADED_AVATAR).to.be.true;
                expect(REMOTEUSER_SET).is.not.null;
                expect(REMOTEUSER_SET.data.avatarurl).equal("654321");
+               expect(REMOTEUSER_SET.data.displayname).is.undefined;
+               expect(DISPLAYNAME_SET).is.null;
+           });
+       });
+       it("Will remove an avatar", () => {
+           const userSync = CreateUserSync();
+           const state: IUserState = {
+               id: "123456",
+               createUser: true,
+               mxUserId: "@_discord_123456:localhost",
+               displayName: null, // Nullable
+               avatarUrl: null, // Nullable
+               avatarId: null,
+               removeAvatar: true,
+           };
+           return userSync.ApplyUserState(state).then(() => {
+               expect(LINK_MX_USER).is.not.null;
+               expect(LINK_RM_USER).is.not.null;
+               expect(AVATAR_SET).is.null;
+               expect(UTIL_UPLOADED_AVATAR).to.be.false;
+               expect(REMOTEUSER_SET).is.not.null;
+               expect(REMOTEUSER_SET.data.avatarurl).is.null;
                expect(REMOTEUSER_SET.data.displayname).is.undefined;
                expect(DISPLAYNAME_SET).is.null;
            });

--- a/test/test_usersyncroniser.ts
+++ b/test/test_usersyncroniser.ts
@@ -1,0 +1,128 @@
+import * as Chai from "chai";
+import * as ChaiAsPromised from "chai-as-promised";
+import { Bridge, RemoteUser } from "matrix-appservice-bridge";
+import {UserSyncroniser} from "../src/usersyncroniser";
+import {MockUser} from "./mocks/user";
+import {DiscordBridgeConfig} from "../src/config";
+
+Chai.use(ChaiAsPromised);
+const expect = Chai.expect;
+
+function CreateUserSync(remoteUsers: any[] = []): UserSyncroniser {
+    const bridge: any = {
+        getUserStore: () => {
+            return {
+                getRemoteUser: (id) => {
+                    const user = remoteUsers.find((u) => u.id === id);
+                    if (user === undefined) {
+                        return null;
+                    }
+                    return user;
+                },
+            };
+        },
+    };
+    const config = new DiscordBridgeConfig();
+    config.bridge.domain = "localhost";
+    return new UserSyncroniser(bridge as Bridge, config);
+}
+
+describe("UserSyncroniser", () => {
+   describe("GetUserUpdateState", () => {
+       it("Will create new users", () => {
+           const userSync = CreateUserSync();
+           const user = new MockUser(
+               "123456",
+               "TestUsername",
+               "6969",
+               "test.jpg",
+               "111",
+           );
+           return userSync.GetUserUpdateState(null, user as any).then((state) => {
+               expect(state.createUser).is.true;
+               expect(state.removeAvatar).is.false;
+               expect(state.displayName).equals("TestUsername#6969");
+               expect(state.mxUserId).equals("@_discord_123456:localhost");
+               expect(state.avatarId).equals("111");
+               expect(state.avatarUrl).equals("test.jpg");
+           });
+       });
+       it("Will change display names", () => {
+           const remoteUser = new RemoteUser("123456", {
+               avatarurl: "test.jpg",
+               displayname: "MrFake",
+           });
+
+           const userSync = CreateUserSync([remoteUser]);
+           const user = new MockUser(
+               "123456",
+               "TestUsername",
+               "6969",
+               "test.jpg",
+               "111",
+           );
+           return userSync.GetUserUpdateState(null, user as any).then((state) => {
+               expect(state.createUser, "CreateUser").is.false;
+               expect(state.removeAvatar, "RemoveAvatar").is.false;
+               expect(state.displayName, "DisplayName").equals("TestUsername#6969");
+               expect(state.mxUserId , "UserId").equals("@_discord_123456:localhost");
+               expect(state.avatarId, "AvatarID").is.null;
+               expect(state.avatarUrl, "AvatarUrl").is.null;
+           });
+       });
+       it("Will change avatars", () => {
+           const remoteUser = new RemoteUser("123456", {
+               avatarurl: "test.jpg",
+               displayname: "TestUsername#6969",
+           });
+
+           const userSync = CreateUserSync([remoteUser]);
+           const user = new MockUser(
+               "123456",
+               "TestUsername",
+               "6969",
+               "test2.jpg",
+               "111",
+           );
+           return userSync.GetUserUpdateState(null, user as any).then((state) => {
+               expect(state.createUser, "CreateUser").is.false;
+               expect(state.removeAvatar, "RemoveAvatar").is.false;
+               expect(state.avatarUrl, "AvatarUrl").equals("test2.jpg");
+               expect(state.mxUserId , "UserId").equals("@_discord_123456:localhost");
+               expect(state.avatarId, "AvatarID").is.equals("111");
+               expect(state.displayName, "DisplayName").is.null;
+           });
+       });
+       it("Will remove avatars", () => {
+           const remoteUser = new RemoteUser("123456", {
+               avatarurl: "test.jpg",
+               displayname: "TestUsername#6969",
+           });
+
+           const userSync = CreateUserSync([remoteUser]);
+           const user = new MockUser(
+               "123456",
+               "TestUsername",
+               "6969",
+               null,
+               null,
+           );
+           return userSync.GetUserUpdateState(null, user as any).then((state) => {
+               expect(state.createUser, "CreateUser").is.false;
+               expect(state.removeAvatar, "RemoveAvatar").is.true;
+               expect(state.avatarUrl, "AvatarUrl").is.null;
+               expect(state.mxUserId , "UserId").equals("@_discord_123456:localhost");
+               expect(state.avatarId, "AvatarID").is.null;
+               expect(state.displayName, "DisplayName").is.null;
+           });
+       });
+   });
+   describe("ApplyUserState", () => {
+       it("Will set a display name", () => {
+
+       });
+       it("Will set a avatar", () => {
+
+       });
+   });
+});

--- a/test/test_usersyncroniser.ts
+++ b/test/test_usersyncroniser.ts
@@ -1,16 +1,39 @@
 import * as Chai from "chai";
 import * as ChaiAsPromised from "chai-as-promised";
 import { Bridge, RemoteUser } from "matrix-appservice-bridge";
-import {UserSyncroniser} from "../src/usersyncroniser";
+import {IUserState, UserSyncroniser} from "../src/usersyncroniser";
 import {MockUser} from "./mocks/user";
 import {DiscordBridgeConfig} from "../src/config";
+import * as Proxyquire from "proxyquire";
 
 Chai.use(ChaiAsPromised);
 const expect = Chai.expect;
 
+let DISPLAYNAME_SET = null;
+let AVATAR_SET = null;
+let REMOTEUSER_SET = null;
+let INTENT_ID = null;
+let LINK_MX_USER = null;
+let LINK_RM_USER = null;
+let UTIL_UPLOADED_AVATAR = false;
+
+const UserSync = (Proxyquire("../src/usersyncroniser", {
+    "./util": {
+        Util: {
+            UploadContentFromUrl: () => {
+                UTIL_UPLOADED_AVATAR = true;
+                return Promise.resolve({mxcUrl: "avatarset"});
+            },
+        },
+    },
+})).UserSyncroniser;
+
 function CreateUserSync(remoteUsers: any[] = []): UserSyncroniser {
     const bridge: any = {
         getUserStore: () => {
+            REMOTEUSER_SET = null;
+            LINK_RM_USER = null;
+            LINK_MX_USER = null;
             return {
                 getRemoteUser: (id) => {
                     const user = remoteUsers.find((u) => u.id === id);
@@ -19,12 +42,35 @@ function CreateUserSync(remoteUsers: any[] = []): UserSyncroniser {
                     }
                     return user;
                 },
+                setRemoteUser: (remoteUser) => {
+                    REMOTEUSER_SET = remoteUser;
+                    return Promise.resolve();
+                },
+                linkUsers: (mxUser, remoteUser) => {
+                    LINK_MX_USER = mxUser;
+                    LINK_RM_USER = remoteUser;
+                },
+            };
+        },
+        getIntent: (id) => {
+            DISPLAYNAME_SET = null;
+            AVATAR_SET = null;
+            INTENT_ID = id;
+            return {
+                setDisplayName: (dn) => {
+                    DISPLAYNAME_SET = dn;
+                    return Promise.resolve();
+                },
+                setAvatarUrl: (ava) => {
+                    AVATAR_SET = ava;
+                    return Promise.resolve();
+                },
             };
         },
     };
     const config = new DiscordBridgeConfig();
     config.bridge.domain = "localhost";
-    return new UserSyncroniser(bridge as Bridge, config);
+    return new UserSync(bridge as Bridge, config);
 }
 
 describe("UserSyncroniser", () => {
@@ -118,11 +164,84 @@ describe("UserSyncroniser", () => {
        });
    });
    describe("ApplyUserState", () => {
-       it("Will set a display name", () => {
-
+       it("Will create a new user", () => {
+           const userSync = CreateUserSync();
+           const state: IUserState = {
+               id: "123456",
+               createUser: true,
+               mxUserId: "@_discord_123456:localhost",
+               displayName: null, // Nullable
+               avatarUrl: null, // Nullable
+               avatarId: null,
+               removeAvatar: false,
+           };
+           return userSync.ApplyUserState(state).then(() => {
+               expect(LINK_MX_USER).is.not.null;
+               expect(LINK_RM_USER).is.not.null;
+               expect(REMOTEUSER_SET).is.null;
+           });
        });
-       it("Will set a avatar", () => {
-
+       it("Will set a display name", () => {
+           const userSync = CreateUserSync();
+           const state: IUserState = {
+               id: "123456",
+               createUser: true,
+               mxUserId: "@_discord_123456:localhost",
+               displayName: "123456", // Nullable
+               avatarUrl: null, // Nullable
+               avatarId: null,
+               removeAvatar: false,
+           };
+           return userSync.ApplyUserState(state).then(() => {
+               expect(LINK_MX_USER).is.not.null;
+               expect(LINK_RM_USER).is.not.null;
+               expect(REMOTEUSER_SET).is.not.null;
+               expect(DISPLAYNAME_SET).equal("123456");
+               expect(REMOTEUSER_SET.data.displayname).equal("123456");
+               expect(AVATAR_SET).is.null;
+               expect(REMOTEUSER_SET.data.avatarurl).is.undefined;
+           });
+       });
+       it("Will set an avatar", () => {
+           const userSync = CreateUserSync();
+           const state: IUserState = {
+               id: "123456",
+               createUser: true,
+               mxUserId: "@_discord_123456:localhost",
+               displayName: null, // Nullable
+               avatarUrl: "654321", // Nullable
+               avatarId: null,
+               removeAvatar: false,
+           };
+           return userSync.ApplyUserState(state).then(() => {
+               expect(LINK_MX_USER).is.not.null;
+               expect(LINK_RM_USER).is.not.null;
+               expect(AVATAR_SET).equal("avatarset");
+               expect(UTIL_UPLOADED_AVATAR).to.be.true;
+               expect(REMOTEUSER_SET).is.not.null;
+               expect(REMOTEUSER_SET.data.avatarurl).equal("654321");
+               expect(REMOTEUSER_SET.data.displayname).is.undefined;
+               expect(DISPLAYNAME_SET).is.null;
+           });
+       });
+       it("Will fetch an existing user", () => {
+           const userSync = CreateUserSync([new RemoteUser("123456")]);
+           const state: IUserState = {
+               id: "123456",
+               createUser: false,
+               mxUserId: "@_discord_123456:localhost",
+               displayName: null, // Nullable
+               avatarUrl: null, // Nullable
+               avatarId: null,
+               removeAvatar: false,
+           };
+           return userSync.ApplyUserState(state).then(() => {
+               expect(LINK_MX_USER).is.null;
+               expect(LINK_RM_USER).is.null;
+               expect(AVATAR_SET).is.null;
+               expect(REMOTEUSER_SET).is.null;
+               expect(DISPLAYNAME_SET).is.null;
+           });
        });
    });
 });

--- a/test/test_usersyncroniser.ts
+++ b/test/test_usersyncroniser.ts
@@ -98,11 +98,15 @@ function CreateUserSync(remoteUsers: any[] = []): UserSyncroniser {
                     AVATAR_SET = ava;
                     return Promise.resolve();
                 },
-                sendStateEvent: (roomId, type, key, content) => {
-                    SEV_ROOM_ID = roomId;
-                    SEV_CONTENT = content;
-                    SEV_KEY = key;
-                    SEV_COUNT++;
+                getClient: () => {
+                    return {
+                        sendStateEvent: (roomId, type, content, key) => {
+                            SEV_ROOM_ID = roomId;
+                            SEV_CONTENT = content;
+                            SEV_KEY = key;
+                            SEV_COUNT++;
+                        },
+                    };
                 },
             };
         },

--- a/test/test_usersyncroniser.ts
+++ b/test/test_usersyncroniser.ts
@@ -123,7 +123,7 @@ function CreateUserSync(remoteUsers: any[] = []): UserSyncroniser {
                 return chan;
             }
             throw new Error("Channel not found"); 
-        }
+        },
     };
     const config = new DiscordBridgeConfig();
     config.bridge.domain = "localhost";
@@ -456,7 +456,7 @@ describe("UserSyncroniser", () => {
                },
                room_id: "!found:localhost",
                state_key: "123456",
-           },0).then(() => {
+           }, 0).then(() => {
                 expect(SEV_COUNT).to.equal(1);
            });
        });
@@ -468,7 +468,7 @@ describe("UserSyncroniser", () => {
                },
                room_id: "!abcdef:localhost",
                state_key: "123456",
-            },0)).to.eventually.equal(UserSyncroniser.ERR_USER_NOT_FOUND);
+            }, 0)).to.eventually.equal(UserSyncroniser.ERR_USER_NOT_FOUND);
        });
        it("will not update state for a unknown room", () => {
             const userSync = CreateUserSync([new RemoteUser("123456")]);
@@ -478,7 +478,7 @@ describe("UserSyncroniser", () => {
                },
                room_id: "!notfound:localhost",
                state_key: "123456",
-            },0)).to.eventually.equal(UserSyncroniser.ERR_CHANNEL_MEMBER_NOT_FOUND);
+            }, 0)).to.eventually.equal(UserSyncroniser.ERR_CHANNEL_MEMBER_NOT_FOUND);
        });
        it("will not update state for a member not found in the channel", () => {
             const userSync = CreateUserSync([new RemoteUser("111222")]);
@@ -488,9 +488,10 @@ describe("UserSyncroniser", () => {
                },
                room_id: "!found:localhost",
                state_key: "111222",
-            },0)).to.eventually.equal(UserSyncroniser.ERR_CHANNEL_MEMBER_NOT_FOUND);
+            }, 0)).to.eventually.equal(UserSyncroniser.ERR_CHANNEL_MEMBER_NOT_FOUND);
        });
        it("will not process old events", () => {
+            const DELAY_MS = 250;
             const userSync = CreateUserSync([new RemoteUser("123456")]);
             return Promise.all([
                 expect(userSync.OnMemberState({
@@ -501,7 +502,7 @@ describe("UserSyncroniser", () => {
                     event_id: "Anicent:localhost",
                     room_id: "!found:localhost",
                     state_key: "123456",
-                },300)).to.eventually.equal(UserSyncroniser.ERR_NEWER_EVENT, "State 1 Failed"),
+                }, DELAY_MS)).to.eventually.equal(UserSyncroniser.ERR_NEWER_EVENT, "State 1 Failed"),
                 expect(userSync.OnMemberState({
                     origin_server_ts: 7000,
                     content: {
@@ -510,7 +511,7 @@ describe("UserSyncroniser", () => {
                     event_id: "QuiteOld:localhost",
                     room_id: "!found:localhost",
                     state_key: "123456",
-                },300)).to.eventually.equal(UserSyncroniser.ERR_NEWER_EVENT, "State 2 Failed"),
+                }, DELAY_MS)).to.eventually.equal(UserSyncroniser.ERR_NEWER_EVENT, "State 2 Failed"),
                 expect(userSync.OnMemberState({
                     origin_server_ts: 3000,
                     content: {
@@ -519,7 +520,7 @@ describe("UserSyncroniser", () => {
                     event_id: "FreshEnough:localhost",
                     room_id: "!found:localhost",
                     state_key: "123456",
-                },300)).to.eventually.equal(UserSyncroniser.ERR_NEWER_EVENT, "State 3 Failed"),
+                }, DELAY_MS)).to.eventually.equal(UserSyncroniser.ERR_NEWER_EVENT, "State 3 Failed"),
                 expect(userSync.OnMemberState({
                     origin_server_ts: 4000,
                     content: {
@@ -528,7 +529,7 @@ describe("UserSyncroniser", () => {
                     event_id: "GettingOnABit:localhost",
                     room_id: "!found:localhost",
                     state_key: "123456",
-                },300)).to.eventually.equal(UserSyncroniser.ERR_NEWER_EVENT, "State 4 Failed"),
+                }, DELAY_MS)).to.eventually.equal(UserSyncroniser.ERR_NEWER_EVENT, "State 4 Failed"),
                 expect(userSync.OnMemberState({
                     origin_server_ts: 100,
                     content: {
@@ -537,7 +538,7 @@ describe("UserSyncroniser", () => {
                     event_id: "FreshOutTheOven:localhost",
                     room_id: "!found:localhost",
                     state_key: "123456",
-                },300)).to.eventually.be.fulfilled
+                }, DELAY_MS)).to.eventually.be.fulfilled,
             ]);
        });
    });

--- a/test/test_usersyncroniser.ts
+++ b/test/test_usersyncroniser.ts
@@ -125,7 +125,7 @@ function CreateUserSync(remoteUsers: any[] = []): UserSyncroniser {
             throw new Error("Channel not found"); 
         },
         GetGuilds: () => {
-            return []
+            return [];
         },
     };
     const config = new DiscordBridgeConfig();

--- a/test/test_usersyncroniser.ts
+++ b/test/test_usersyncroniser.ts
@@ -98,7 +98,7 @@ function CreateUserSync(remoteUsers: any[] = []): UserSyncroniser {
                     AVATAR_SET = ava;
                     return Promise.resolve();
                 },
-                sendStateEvent: (roomId, type, content, key) => {
+                sendStateEvent: (roomId, type, key, content) => {
                     SEV_ROOM_ID = roomId;
                     SEV_CONTENT = content;
                     SEV_KEY = key;
@@ -123,6 +123,9 @@ function CreateUserSync(remoteUsers: any[] = []): UserSyncroniser {
                 return chan;
             }
             throw new Error("Channel not found"); 
+        },
+        GetGuilds: () => {
+            return []
         },
     };
     const config = new DiscordBridgeConfig();


### PR DESCRIPTION
This change removes the UpdateUser function and instead spreads out that functionality to a UserSync class where we make the algorithm more verbose and easier to test. 

What does this do:

* Users are now joined and left from the guilds appropriately
* Profile updates are made, and guild nicks overwrite them automatically.
* Pulled out more code from ``bot.ts``

Fixes #56, #101 and #102 