### PR TITLE
Clarify where to specify appservice protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,11 @@ Please also be aware that this is an unoffical project worked on in my (Half-Sho
 #### 3PID Protocol Support
 
 This bridge support searching for rooms within networks via the 3pid system
-used in clients like [Riot](https://riot.im). However, it requires a small manual change
-to your registration file. Add ``protocols: ["discord"]`` to the end and restart both your bridge
-and synapse. Any new servers/guilds you bridge should show up in the network list on Riot and other clients.
+used in clients like [Riot](https://riot.im). However, it requires a small
+manual change to your registration file. Change the end of
+`discord-registration.yaml` to `protocols: ["discord"]`` and restart both your
+bridge and synapse. Any new servers/guilds you bridge should show up in the
+network list on Riot and other clients.
 
 ### Setting up Discord
 


### PR DESCRIPTION
So I just realized that `protocols: ["discord"]` is supported to go at the end of `discord-registration.yaml`, not `homeserver.yaml` aka I'm dumb.

Hopefully this makes other people not so dumb too.