### PR TITLE
Display name, topic and membership changes on Discord.

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -182,22 +182,26 @@ export class DiscordBot {
   }
 
   public async ProcessMatrixStateEvent(event: any): Promise<void> {
-      log.verbose("DiscordBot", `Got state event from ${roomId} ${event.type}`);
-      const channel = await this.GetChannelFromRoomId(event.room_id);
+      log.verbose(`Got state event from ${event.room_id} ${event.type}`);
+      const channel = <Discord.TextChannel> await this.GetChannelFromRoomId(event.room_id);
       const msg = this.mxEventProcessor.StateEventToMessage(event, channel);
-      if (msg == undefined) {
+      if (!msg) {
           return;
       }
-      res = await chan.send(msg);
-      log.verbose("DiscordBot", "Sent (state msg) ", res);
-      this.sentMessages.push(res.id);
-      const evt = new DbEvent();
-      evt.MatrixId = event.event_id + ";" + event.room_id;
-      evt.DiscordId = res.id;
-      evt.GuildId = channel.guild.id;
-      evt.ChannelId = channel.id;
-      await this.store.Insert(evt);
-      return;
+      let res = await channel.send(msg);
+      if (!Array.isArray(res)) {
+        res = [res];
+      }
+      res.forEach((m: Discord.Message) => {
+        log.verbose("Sent (state msg) ", m);
+        this.sentMessages.push(m.id);
+        const evt = new DbEvent();
+        evt.MatrixId = event.event_id + ";" + event.room_id;
+        evt.DiscordId = m.id;
+        evt.GuildId = channel.guild.id;
+        evt.ChannelId = channel.id;
+        return this.store.Insert(evt);
+      });
   }
 
   public async ProcessMatrixMsgEvent(event: any, guildId: string, channelId: string): Promise<null> {

--- a/src/matrixeventprocessor.ts
+++ b/src/matrixeventprocessor.ts
@@ -172,12 +172,12 @@ export class MatrixEventProcessor {
         }
 
         if (event.content.info == null) {
-            log.info("MatrixEventProcessor", "Event was an attachment type but was missing a content.info");
+            log.info("Event was an attachment type but was missing a content.info");
             return "";
         }
 
         if (event.content.url == null) {
-            log.info("MatrixEventProcessor", "Event was an attachment type but was missing a content.url");
+            log.info("Event was an attachment type but was missing a content.url");
             return "";
         }
 

--- a/src/matrixeventprocessor.ts
+++ b/src/matrixeventprocessor.ts
@@ -36,40 +36,39 @@ export class MatrixEventProcessor {
     public StateEventToMessage(event: any, channel: Discord.TextChannel): string {
         const SUPPORTED_EVENTS = ["m.room.member", "m.room.name", "m.room.topic"];
         if (!SUPPORTED_EVENTS.includes(event.type)) {
-            log.verbose("MatrixEventProcessor", `${event.event_id} ${event.type} is not displayable.`);
+            log.verbose(`${event.event_id} ${event.type} is not displayable.`);
             return;
         }
 
-        let msg = `@${event.sender} `;
+        if (event.sender === this.bridge.getIntent().getClient().getUserId()) {
+            log.verbose(`${event.event_id} ${event.type} is by our bot user, ignoring.`);
+            return;
+        }
+
+        let msg = `\`${event.sender}\` `;
 
         if (event.type === "m.room.name") {
-            msg += `set the name to ${event.content.name}`;
+            msg += `set the name to \`${event.content.name}\``;
         } else if (event.type === "m.room.topic") {
-            msg += `set the topic to ${event.content.topic}`;
+            msg += `set the topic to \`${event.content.topic}\``;
         } else if (event.type === "m.room.member") {
             const membership = event.content.membership;
             if (membership === "join"
-                && event.unsigned.prev_content == undefined) {
+                && event.unsigned.prev_content === undefined) {
                 msg += `joined the room`;
             } else if (membership === "invite") {
-                msg += `invited ${event.state_key} to the room`;
+                msg += `invited \`${event.state_key}\` to the room`;
             } else if (membership === "leave" && event.state_key !== event.sender) {
-                msg += `kicked ${event.state_key} from the room`;
+                msg += `kicked \`${event.state_key}\` from the room`;
             } else if (membership === "leave") {
                 msg += `left the room`;
             } else if (membership === "ban") {
-                msg += `banned ${event.state_key} from the room`;
+                msg += `banned \`${event.state_key}\` from the room`;
             }
         }
 
-        if (!this.config.bridge.disableDiscordMentions) {
-            msg = this.FindMentionsInPlainBody(
-                msg,
-                channel.members.array(),
-            );
-        }
-
         msg += " on Matrix.";
+        return msg;
     }
 
     public EventToEmbed(event: any, profile: any|null, channel: Discord.TextChannel): Discord.RichEmbed {

--- a/src/matrixroomhandler.ts
+++ b/src/matrixroomhandler.ts
@@ -90,6 +90,12 @@ export class MatrixRoomHandler {
     }
     if (event.type === "m.room.member" && event.content.membership === "invite") {
       return this.HandleInvite(event);
+    } else if (event.type === "m.room.member") {
+      return this.ProcessMatrixStateEvent(event);
+    } else if (event.type === "m.room.name") {    
+      return this.ProcessMatrixStateEvent(event);
+    } else if (event.type === "m.room.topic") {
+      return this.ProcessMatrixStateEvent(event);
     } else if (event.type === "m.room.redaction" && context.rooms.remote) {
       return this.discord.ProcessMatrixRedact(event);
     } else if (event.type === "m.room.message") {
@@ -136,6 +142,8 @@ export class MatrixRoomHandler {
     if (event.state_key === this.botUserId) {
       log.info("MatrixRoomHandler", "Accepting invite for bridge bot");
       return this.joinRoom(this.bridge.getIntent(), event.room_id);
+    } else {
+      return this.ProcessMatrixStateEvent(event);
     }
   }
 

--- a/src/matrixroomhandler.ts
+++ b/src/matrixroomhandler.ts
@@ -98,31 +98,33 @@ export class MatrixRoomHandler {
   public OnEvent (request, context): Promise<any> {
     const event = request.getData();
     if (event.unsigned.age > AGE_LIMIT) {
-      log.warn("MatrixRoomHandler", "Skipping event due to age %s > %s", event.unsigned.age, AGE_LIMIT);
+      log.warn("Skipping event due to age %s > %s", event.unsigned.age, AGE_LIMIT);
       return Promise.reject("Event too old");
     }
     if (event.type === "m.room.member" && event.content.membership === "invite") {
       return this.HandleInvite(event);
-    } else if (event.type === "m.room.member") {
-      return this.ProcessMatrixStateEvent(event);
-    } else if (event.type === "m.room.name") {    
-      return this.ProcessMatrixStateEvent(event);
-    } else if (event.type === "m.room.topic") {
-      return this.ProcessMatrixStateEvent(event);
     } else if (event.type === "m.room.member" && event.content.membership === "join") {
         if (this.bridge.getBot()._isRemoteUser(event.state_key)) {
             return this.discord.UserSyncroniser.OnMemberState(event, USERSYNC_STATE_DELAY_MS);
+        } else {
+          return this.discord.ProcessMatrixStateEvent(event);
         }
+    } else if (event.type === "m.room.member") {
+      return this.discord.ProcessMatrixStateEvent(event);
+    } else if (event.type === "m.room.name") {    
+      return this.discord.ProcessMatrixStateEvent(event);
+    } else if (event.type === "m.room.topic") {
+      return this.discord.ProcessMatrixStateEvent(event);
     } else if (event.type === "m.room.redaction" && context.rooms.remote) {
       return this.discord.ProcessMatrixRedact(event);
     } else if (event.type === "m.room.message") {
-        log.verbose("MatrixRoomHandler", "Got m.room.message event");
+        log.verbose("Got m.room.message event");
         if (event.content.body && event.content.body.startsWith("!discord")) {
             return this.ProcessCommand(event, context);
         } else if (context.rooms.remote) {
             const srvChanPair = context.rooms.remote.roomId.substr("_discord".length).split("_", ROOM_NAME_PARTS);
             return this.discord.ProcessMatrixMsgEvent(event, srvChanPair[0], srvChanPair[1]).catch((err) => {
-                log.warn("MatrixRoomHandler", "There was an error sending a matrix event", err);
+                log.warn("There was an error sending a matrix event", err);
             });
         }
     } else if (event.type === "m.room.encryption" && context.rooms.remote) {
@@ -130,14 +132,14 @@ export class MatrixRoomHandler {
             return Promise.reject(`Failed to handle encrypted room, ${err}`);
         });
     } else {
-      log.verbose("MatrixRoomHandler", "Got non m.room.message event");
+      log.verbose("Got non m.room.message event");
     }
     return Promise.reject("Event not processed by bridge");
   }
 
   public async HandleEncryptionWarning(roomId: string): Promise<void> {
       const intent = this.bridge.getIntent();
-      log.info("MatrixRoomHandler", `User has turned on encryption in ${roomId}, so leaving.`);
+      log.info(`User has turned on encryption in ${roomId}, so leaving.`);
       /* N.B 'status' is not specced but https://github.com/matrix-org/matrix-doc/pull/828
        has been open for over a year with no resolution. */
       const sendPromise = intent.sendMessage(roomId, {
@@ -155,12 +157,12 @@ export class MatrixRoomHandler {
   }
 
   public HandleInvite(event: any) {
-    log.info("MatrixRoomHandler", "Received invite for " + event.state_key + " in room " + event.room_id);
+    log.info("Received invite for " + event.state_key + " in room " + event.room_id);
     if (event.state_key === this.botUserId) {
-      log.info("MatrixRoomHandler", "Accepting invite for bridge bot");
+      log.info("Accepting invite for bridge bot");
       return this.joinRoom(this.bridge.getIntent(), event.room_id);
     } else {
-      return this.ProcessMatrixStateEvent(event);
+      return this.discord.ProcessMatrixStateEvent(event);
     }
   }
 
@@ -244,7 +246,7 @@ export class MatrixRoomHandler {
               const discordResult = await this.discord.LookupRoom(guildId, channelId);
               const channel = <Discord.TextChannel> discordResult.channel;
 
-              log.info("MatrixRoomHandler", `Bridging matrix room ${event.room_id} to ${guildId}/${channelId}`);
+              log.info(`Bridging matrix room ${event.room_id} to ${guildId}/${channelId}`);
               this.bridge.getIntent().sendMessage(event.room_id, {
                   msgtype: "m.notice",
                   body: "I'm asking permission from the guild administrators to make this bridge.",
@@ -265,8 +267,8 @@ export class MatrixRoomHandler {
                   });
               }
 
-              log.error("MatrixRoomHandler", `Error bridging ${event.room_id} to ${guildId}/${channelId}`);
-              log.error("MatrixRoomHandler", err);
+              log.error(`Error bridging ${event.room_id} to ${guildId}/${channelId}`);
+              log.error(err);
               return this.bridge.getIntent().sendMessage(event.room_id, {
                   msgtype: "m.notice",
                   body: "There was a problem bridging that channel - has the guild owner approved the bridge?",
@@ -296,8 +298,8 @@ export class MatrixRoomHandler {
                   body: "This room has been unbridged",
               });
           } catch (err) {
-              log.error("MatrixRoomHandler", "Error while unbridging room " + event.room_id);
-              log.error("MatrixRoomHandler", err);
+              log.error("Error while unbridging room " + event.room_id);
+              log.error(err);
               return this.bridge.getIntent().sendMessage(event.room_id, {
                   msgtype: "m.notice",
                   body: "There was an error unbridging this room. " +
@@ -317,17 +319,17 @@ export class MatrixRoomHandler {
   }
 
   public OnAliasQuery (alias: string, aliasLocalpart: string): Promise<any> {
-    log.info("MatrixRoomHandler", "Got request for #", aliasLocalpart);
+    log.info("Got request for #", aliasLocalpart);
     const srvChanPair = aliasLocalpart.substr("_discord_".length).split("_", ROOM_NAME_PARTS);
     if (srvChanPair.length < ROOM_NAME_PARTS || srvChanPair[0] === "" || srvChanPair[1] === "") {
-      log.warn("MatrixRoomHandler", `Alias '${aliasLocalpart}' was missing a server and/or a channel`);
+      log.warn(`Alias '${aliasLocalpart}' was missing a server and/or a channel`);
       return;
     }
     return this.discord.LookupRoom(srvChanPair[0], srvChanPair[1]).then((result) => {
-      log.info("MatrixRoomHandler", "Creating #", aliasLocalpart);
+      log.info("Creating #", aliasLocalpart);
       return this.createMatrixRoom(result.channel, aliasLocalpart);
     }).catch((err) => {
-      log.error("MatrixRoomHandler", `Couldn't find discord room '${aliasLocalpart}'.`, err);
+      log.error(`Couldn't find discord room '${aliasLocalpart}'.`, err);
     });
   }
 
@@ -376,7 +378,7 @@ export class MatrixRoomHandler {
   }
 
   public tpGetLocation(protocol: string, fields: any): Promise<thirdPartyLocationResult[]> {
-    log.info("MatrixRoomHandler", "Got location request ", protocol, fields);
+    log.info("Got location request ", protocol, fields);
     const chans = this.discord.ThirdpartySearchForChannels(fields.guild_id, fields.channel_name);
     return Promise.resolve(chans);
   }
@@ -386,7 +388,7 @@ export class MatrixRoomHandler {
   }
 
   public tpGetUser(protocol: string, fields: any): Promise<thirdPartyUserResult[]> {
-    log.info("MatrixRoomHandler", "Got user request ", protocol, fields);
+    log.info("Got user request ", protocol, fields);
     return Promise.reject({err: "Unsupported", code: HTTP_UNSUPPORTED});
   }
 
@@ -398,11 +400,11 @@ export class MatrixRoomHandler {
       let currentSchedule = JOIN_ROOM_SCHEDULE[0];
       const doJoin = () => Util.DelayedPromise(currentSchedule).then(() => intent.getClient().joinRoom(roomIdOrAlias));
       const errorHandler = (err) => {
-          log.error("MatrixRoomHandler", `Error joining room ${roomIdOrAlias} as ${intent.getClient().getUserId()}`);
-          log.error("MatrixRoomHandler", err);
+          log.error(`Error joining room ${roomIdOrAlias} as ${intent.getClient().getUserId()}`);
+          log.error(err);
           const idx = JOIN_ROOM_SCHEDULE.indexOf(currentSchedule);
           if (idx === JOIN_ROOM_SCHEDULE.length - 1) {
-              log.warn("MatrixRoomHandler", `Cannot join ${roomIdOrAlias} as ${intent.getClient().getUserId()}`);
+              log.warn(`Cannot join ${roomIdOrAlias} as ${intent.getClient().getUserId()}`);
               return Promise.reject(err);
           } else {
               currentSchedule = JOIN_ROOM_SCHEDULE[idx + 1];

--- a/test/test_matrixeventprocessor.ts
+++ b/test/test_matrixeventprocessor.ts
@@ -102,7 +102,7 @@ describe("MatrixEventProcessor", () => {
             const msg = processor.StateEventToMessage(event, channel as any);
             Chai.assert.equal(msg, undefined);
         });
-        it("Should set name changes", () => {
+        it("Should echo name changes", () => {
             const processor = createMatrixEventProcessor();
             const event = {
                 sender: "@user:localhost",
@@ -115,7 +115,7 @@ describe("MatrixEventProcessor", () => {
             const msg = processor.StateEventToMessage(event, channel as any);
             Chai.assert.equal(msg, "`@user:localhost` set the name to `Test Name` on Matrix.");
         });
-        it("Should set topic changes", () => {
+        it("Should echo topic changes", () => {
             const processor = createMatrixEventProcessor();
             const event = {
                 sender: "@user:localhost",
@@ -128,7 +128,7 @@ describe("MatrixEventProcessor", () => {
             const msg = processor.StateEventToMessage(event, channel as any);
             Chai.assert.equal(msg, "`@user:localhost` set the topic to `Test Topic` on Matrix.");
         });
-        it("Should set joins", () => {
+        it("Should echo joins", () => {
             const processor = createMatrixEventProcessor();
             const event = {
                 sender: "@user:localhost",
@@ -142,7 +142,7 @@ describe("MatrixEventProcessor", () => {
             const msg = processor.StateEventToMessage(event, channel as any);
             Chai.assert.equal(msg, "`@user:localhost` joined the room on Matrix.");
         });
-        it("Should set invites", () => {
+        it("Should echo invites", () => {
             const processor = createMatrixEventProcessor();
             const event = {
                 sender: "@user:localhost",
@@ -157,7 +157,7 @@ describe("MatrixEventProcessor", () => {
             const msg = processor.StateEventToMessage(event, channel as any);
             Chai.assert.equal(msg, "`@user:localhost` invited `@user2:localhost` to the room on Matrix.");
         });
-        it("Should set kicks", () => {
+        it("Should echo kicks", () => {
             const processor = createMatrixEventProcessor();
             const event = {
                 sender: "@user:localhost",
@@ -172,7 +172,7 @@ describe("MatrixEventProcessor", () => {
             const msg = processor.StateEventToMessage(event, channel as any);
             Chai.assert.equal(msg, "`@user:localhost` kicked `@user2:localhost` from the room on Matrix.");
         });
-        it("Should set leaves", () => {
+        it("Should echo leaves", () => {
             const processor = createMatrixEventProcessor();
             const event = {
                 sender: "@user:localhost",
@@ -187,7 +187,7 @@ describe("MatrixEventProcessor", () => {
             const msg = processor.StateEventToMessage(event, channel as any);
             Chai.assert.equal(msg, "`@user:localhost` left the room on Matrix.");
         });
-        it("Should set bans", () => {
+        it("Should echo bans", () => {
             const processor = createMatrixEventProcessor();
             const event = {
                 sender: "@user:localhost",

--- a/test/test_matrixroomhandler.ts
+++ b/test/test_matrixroomhandler.ts
@@ -81,6 +81,7 @@ function createRH(opts: any = {}) {
         GetBotId: () => "bot12345",
         ProcessMatrixRedact: () => Promise.resolve("redacted"),
         ProcessMatrixMsgEvent: () => Promise.resolve("processed"),
+        ProcessMatrixStateEvent: () => Promise.resolve("stateevent"),
         LookupRoom: (guildid, discordid) => {
             if (guildid !== "123") {
                 return Promise.reject("Guild not found");
@@ -186,13 +187,13 @@ describe("MatrixRoomHandler", () => {
                 state_key: "@_discord_12345:localhost",
                 type: "m.room.member"}), null)).to.eventually.equal("user_sync_handled");
         });
-        it("should ignore other member types", () => {
+        it("should pass other member types to state event", () => {
             const handler = createRH();
             handler.HandleInvite = (ev) => Promise.resolve("invited");
             return expect(handler.OnEvent(buildRequest({
                 content: {membership: "join"},
                 state_key: "@bacon:localhost",
-                type: "m.room.member"}), null)).to.be.rejectedWith("Event not processed by bridge");
+                type: "m.room.member"}), null)).to.eventually.equal("stateevent");
         });
         it("should handle redactions with existing rooms", () => {
             const handler = createRH();
@@ -270,7 +271,7 @@ describe("MatrixRoomHandler", () => {
             handler.joinRoom = () => Promise.resolve("joinedroom");
             return expect(handler.HandleInvite({
                 state_key: "@user:localhost",
-            })).to.be.undefined;
+            })).to.eventually.be.equal("stateevent");
         });
     });
     describe("ProcessCommand", () => {


### PR DESCRIPTION
Fixes #155 

This just consumes state events and sends a message from the bot into the bridged channel.