### PR TITLE
Presence should use User rather than GuildMember

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -73,7 +73,9 @@ export class DiscordBot {
         client.on("typingStop", (c, u) => { this.OnTyping(c, u, false);  });
       }
       if (!this.config.bridge.disablePresence) {
-        client.on("presenceUpdate", (_, newMember) => { this.presenceHandler.EnqueueMember(newMember); });
+        client.on("presenceUpdate", (_, newMember: Discord.GuildMember) => {
+          this.presenceHandler.EnqueueUser(newMember.user); 
+        });
       }
       client.on("userUpdate", (_, newUser) => { this.UpdateUser(newUser); });
       client.on("channelUpdate", (_, newChannel) => { this.UpdateRooms(newChannel); });
@@ -98,7 +100,7 @@ export class DiscordBot {
         }
         this.bot.guilds.forEach((guild) => {
             guild.members.forEach((member) => {
-                this.presenceHandler.EnqueueMember(member);
+                this.presenceHandler.EnqueueUser(member.user);
             });
         });
         this.presenceHandler.Start(
@@ -470,7 +472,6 @@ export class DiscordBot {
   private RemoveGuildMember(guildMember: Discord.GuildMember) {
     const intent = this.GetIntentFromDiscordMember(guildMember);
     return Bluebird.each(this.GetRoomIdsFromGuild(guildMember.guild.id), (roomId) => {
-        this.presenceHandler.DequeueMember(guildMember);
         return intent.leave(roomId);
     });
   }

--- a/src/presencehandler.ts
+++ b/src/presencehandler.ts
@@ -1,4 +1,4 @@
-import * as Discord from "discord.js";
+import {User, Presence} from "discord.js";
 import * as log from "npmlog";
 import { DiscordBot } from "./bot";
 
@@ -11,11 +11,11 @@ export class PresenceHandlerStatus {
 
 export class PresenceHandler {
     private readonly bot: DiscordBot;
-    private presenceQueue: Discord.GuildMember[];
+    private presenceQueue: User[];
     private interval: number;
     constructor (bot: DiscordBot) {
         this.bot = bot;
-        this.presenceQueue = new Array();
+        this.presenceQueue = [];
     }
 
     get QueueCount (): number {
@@ -40,45 +40,45 @@ export class PresenceHandler {
         this.interval = null;
     }
 
-    public EnqueueMember(member: Discord.GuildMember) {
-        if (!this.presenceQueue.includes(member)) {
-            log.info("PresenceHandler", `Adding ${member.id} (${member.user.username}) to the presence queue`);
-            this.presenceQueue.push(member);
+    public EnqueueUser(user: User) {
+        if (this.presenceQueue.find((u) => u.id === user.id) === undefined) {
+            log.info("PresenceHandler", `Adding ${user.id} (${user.username}) to the presence queue`);
+            this.presenceQueue.push(user);
         }
     }
 
-    public DequeueMember(member: Discord.GuildMember) {
+    public DequeueUser(user: User) {
         const index = this.presenceQueue.findIndex((item) => {
-            return member === item;
+            return user.id === item.id;
         });
         if (index !== -1) {
             this.presenceQueue.splice(index, 1);
         } else {
             log.warn(
                 "PresenceHandler",
-                `Tried to remove ${member.id} from the presence queue but it could not be found`,
+                `Tried to remove ${user.id} from the presence queue but it could not be found`,
             );
         }
     }
 
-    public ProcessMember(member: Discord.GuildMember): boolean {
-        const status = this.getUserPresence(member.presence);
-        this.setMatrixPresence(member, status);
+    public ProcessUser(user: User): boolean {
+        const status = this.getUserPresence(user.presence);
+        this.setMatrixPresence(user, status);
         return status.ShouldDrop;
     }
 
     private processIntervalThread() {
-        const member = this.presenceQueue.shift();
-        if (member) {
-            if (!this.ProcessMember(member)) {
-                this.presenceQueue.push(member);
+        const user = this.presenceQueue.shift();
+        if (user) {
+            if (!this.ProcessUser(user)) {
+                this.presenceQueue.push(user);
             } else {
-                log.info("PresenceHandler", `Dropping ${member.id} from the presence queue.`);
+                log.info("PresenceHandler", `Dropping ${user.id} from the presence queue.`);
             }
         }
     }
 
-    private getUserPresence(presence: Discord.Presence): PresenceHandlerStatus {
+    private getUserPresence(presence: Presence): PresenceHandlerStatus {
         const status = new PresenceHandlerStatus();
 
         if (presence.game) {
@@ -102,14 +102,14 @@ export class PresenceHandler {
         return status;
     }
 
-    private setMatrixPresence(guildMember: Discord.GuildMember, status: PresenceHandlerStatus) {
-        const intent = this.bot.GetIntentFromDiscordMember(guildMember);
+    private setMatrixPresence(user: User, status: PresenceHandlerStatus) {
+        const intent = this.bot.GetIntentFromDiscordMember(user);
         const statusObj: any = {presence: status.Presence};
         if (status.StatusMsg) {
             statusObj.status_msg = status.StatusMsg;
         }
         intent.getClient().setPresence(statusObj).catch((ex) => {
-            log.warn("PresenceHandler", `Could not update Matrix presence for ${guildMember.id}`);
+            log.warn("PresenceHandler", `Could not update Matrix presence for ${user.id}`);
         });
     }
 }

--- a/test/mocks/user.ts
+++ b/test/mocks/user.ts
@@ -1,9 +1,16 @@
+import { Presence } from "discord.js";
+
 export class MockUser {
   public id = "";
   public username: string;
   public discriminator: string;
+  public presence: Presence;
   constructor(id: string, username: string = "") {
     this.id = id;
     this.username = username;
+  }
+
+  public MockSetPresence(presence: Presence) {
+      this.presence = presence;
   }
 }

--- a/test/test_presencehandler.ts
+++ b/test/test_presencehandler.ts
@@ -4,11 +4,9 @@ import * as log from "npmlog";
 import * as Discord from "discord.js";
 import * as Proxyquire from "proxyquire";
 
-// import * as Proxyquire from "proxyquire";
 import { PresenceHandler } from "../src/presencehandler";
 import { DiscordBot } from "../src/bot";
-import { MockGuild } from "./mocks/guild";
-import { MockMember } from "./mocks/member";
+import { MockUser } from "./mocks/user";
 
 Chai.use(ChaiAsPromised);
 const expect = Chai.expect;
@@ -49,51 +47,50 @@ describe("PresenceHandler", () => {
             handler.Stop();
         });
     });
-    describe("EnqueueMember", () => {
+    describe("EnqueueUser", () => {
         it("adds a user properly", () => {
             const handler = new PresenceHandler(<DiscordBot> bot);
             const COUNT = 2;
-            handler.EnqueueMember(<any> new MockMember("abc", "def"));
-            handler.EnqueueMember(<any> new MockMember("abc", "ghi"));
+            handler.EnqueueUser(<any> new MockUser("abc", "def"));
+            handler.EnqueueUser(<any> new MockUser("123", "ghi"));
             Chai.assert.equal(handler.QueueCount, COUNT);
         });
         it("does not add duplicate users", () => {
             const handler = new PresenceHandler(<DiscordBot> bot);
-            const member = <any> new MockMember("abc", "def");
-            handler.EnqueueMember(member);
-            handler.EnqueueMember(member);
+            handler.EnqueueUser(<any> new MockUser("abc", "def"));
+            handler.EnqueueUser(<any> new MockUser("abc", "def"));
             Chai.assert.equal(handler.QueueCount, 1);
         });
     });
-    describe("DequeueMember", () => {
+    describe("DequeueUser", () => {
         it("removes users properly", () => {
             const handler = new PresenceHandler(<DiscordBot> bot);
             const members = [
-                <any> new MockMember("abc", "def"),
-                <any> new MockMember("abc", "ghi"),
-                <any> new MockMember("abc", "wew"),
+                <any> new MockUser("abc", "def"),
+                <any> new MockUser("def", "ghi"),
+                <any> new MockUser("ghi", "wew"),
             ];
-            handler.EnqueueMember(members[0]);
-            handler.EnqueueMember(members[1]);
-            handler.EnqueueMember(members[members.length - 1]);
+            handler.EnqueueUser(members[0]);
+            handler.EnqueueUser(members[1]);
+            handler.EnqueueUser(members[members.length - 1]);
 
-            handler.DequeueMember(members[members.length - 1]);
+            handler.DequeueUser(members[members.length - 1]);
             Chai.assert.equal(handler.QueueCount, members.length - 1);
-            handler.DequeueMember(members[1]);
+            handler.DequeueUser(members[1]);
             Chai.assert.equal(handler.QueueCount, 1);
-            handler.DequeueMember(members[0]);
+            handler.DequeueUser(members[0]);
             Chai.assert.equal(handler.QueueCount, 0);
         });
     });
-    describe("ProcessMember", () => {
+    describe("ProcessUser", () => {
         it("processes an online user", () => {
             lastStatus = null;
             const handler = new PresenceHandler(<DiscordBot> bot);
-            const member = <any> new MockMember("abc", "def");
+            const member = <any> new MockUser("abc", "def");
             member.MockSetPresence(new Discord.Presence({
                 status: "online",
             }));
-            handler.ProcessMember(member);
+            handler.ProcessUser(member);
             Chai.assert.deepEqual(lastStatus, {
                 presence: "online",
             });
@@ -101,11 +98,11 @@ describe("PresenceHandler", () => {
         it("processes an offline user", () => {
             lastStatus = null;
             const handler = new PresenceHandler(<DiscordBot> bot);
-            const member = <any> new MockMember("abc", "def");
+            const member = <any> new MockUser("abc", "def");
             member.MockSetPresence(new Discord.Presence({
                 status: "offline",
             }));
-            handler.ProcessMember(member);
+            handler.ProcessUser(member);
             Chai.assert.deepEqual(lastStatus, {
                 presence: "offline",
             });
@@ -114,11 +111,11 @@ describe("PresenceHandler", () => {
         it("processes an idle user", () => {
             lastStatus = null;
             const handler = new PresenceHandler(<DiscordBot> bot);
-            const member = <any> new MockMember("abc", "def");
+            const member = <any> new MockUser("abc", "def");
             member.MockSetPresence(new Discord.Presence({
                 status: "idle",
             }));
-            handler.ProcessMember(member);
+            handler.ProcessUser(member);
             Chai.assert.deepEqual(lastStatus, {
                 presence: "unavailable",
             });
@@ -126,11 +123,11 @@ describe("PresenceHandler", () => {
         it("processes an dnd user", () => {
             lastStatus = null;
             const handler = new PresenceHandler(<DiscordBot> bot);
-            const member = <any> new MockMember("abc", "def");
+            const member = <any> new MockUser("abc", "def");
             member.MockSetPresence(new Discord.Presence({
                 status: "dnd",
             }));
-            handler.ProcessMember(member);
+            handler.ProcessUser(member);
             Chai.assert.deepEqual(lastStatus, {
                 presence: "online",
                 status_msg: "Do not disturb",
@@ -139,7 +136,7 @@ describe("PresenceHandler", () => {
                 status: "dnd",
                 game: new Discord.Game({name: "Test Game"}),
             }));
-            handler.ProcessMember(member);
+            handler.ProcessUser(member);
             Chai.assert.deepEqual(lastStatus, {
                 presence: "online",
                 status_msg: "Do not disturb | Playing Test Game",
@@ -148,12 +145,12 @@ describe("PresenceHandler", () => {
         it("processes a user playing games", () => {
             lastStatus = null;
             const handler = new PresenceHandler(<DiscordBot> bot);
-            const member = <any> new MockMember("abc", "def");
+            const member = <any> new MockUser("abc", "def");
             member.MockSetPresence(new Discord.Presence({
                 status: "online",
                 game: new Discord.Game({name: "Test Game"}),
             }));
-            handler.ProcessMember(member);
+            handler.ProcessUser(member);
             Chai.assert.deepEqual(lastStatus, {
                 presence: "online",
                 status_msg: "Playing Test Game",
@@ -162,7 +159,7 @@ describe("PresenceHandler", () => {
                 status: "online",
                 game: new Discord.Game({name: "Test Game", type: 1}),
             }));
-            handler.ProcessMember(member);
+            handler.ProcessUser(member);
             Chai.assert.deepEqual(lastStatus, {
                 presence: "online",
                 status_msg: "Streaming Test Game",


### PR DESCRIPTION
Why:
- Dedupes by using users rather than guild members
- We now do comparisons by id rather than instance.

Fixes #143 