### PR TITLE
changing username respects guild overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ discord-registration.yaml
 build
 
 *.db
+*.db.backup

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -413,6 +413,20 @@ export class DiscordBot {
       }
       return Promise.resolve();
     }).then(() => {
+      if (remoteUser.get("avatarurl") !== discordUser.avatarURL && discordUser.avatarURL !== null) {
+        return Util.UploadContentFromUrl(
+          discordUser.avatarURL,
+          intent,
+          discordUser.avatar,
+        ).then((avatar) => {
+          intent.setAvatarUrl(avatar.mxcUrl).then(() => {
+            remoteUser.set("avatarurl", discordUser.avatarURL);
+            return userStore.setRemoteUser(remoteUser);
+          });
+        });
+      }
+      return true;
+    }).then(() => {
       if (remoteUser.get("displayname") !== displayName) {
         // iterate over guilds and do the stuff right
         const avatar = remoteUser.get("avatarurl");
@@ -438,20 +452,6 @@ export class DiscordBot {
         });
         return Bluebird.all(updates).then(() => {
           remoteUser.set("displayname", displayName);
-        });
-      }
-      return true;
-    }).then(() => {
-      if (remoteUser.get("avatarurl") !== discordUser.avatarURL && discordUser.avatarURL !== null) {
-        return Util.UploadContentFromUrl(
-          discordUser.avatarURL,
-          intent,
-          discordUser.avatar,
-        ).then((avatar) => {
-          intent.setAvatarUrl(avatar.mxcUrl).then(() => {
-            remoteUser.set("avatarurl", discordUser.avatarURL);
-            return userStore.setRemoteUser(remoteUser);
-          });
         });
       }
       return true;

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -424,10 +424,11 @@ export class DiscordBot {
                 if (discordUser.id === member.id) {
                   updates.push(Bluebird.each(this.GetRoomIdsFromGuild(member.guild.id), (room) => {
                       log.verbose(`Updating ${room}`);
+                      const nick = member.displayName ? member.displayName : displayName;
                       client.sendStateEvent(room, "m.room.member", {
                         membership: "join",
                         avatar_url: avatar,
-                        displayname: member.displayName,
+                        displayname: nick,
                       }, userId);
                     }).catch((err) => {
                       log.error("DiscordBot", "Failed to update guild member %s", err);

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -419,17 +419,24 @@ export class DiscordBot {
           intent,
           discordUser.avatar,
         ).then((avatar) => {
-          intent.setAvatarUrl(avatar.mxcUrl).then(() => {
-            remoteUser.set("avatarurl", discordUser.avatarURL);
-            return userStore.setRemoteUser(remoteUser);
-          });
+          remoteUser.set("avatarurl", discordUser.avatarURL);
+          return {
+            avatar: avatar.mxcUrl,
+            avatar_change: true,
+          };
         });
       }
-      return true;
-    }).then(() => {
-      if (remoteUser.get("displayname") !== displayName) {
+      const client = this.GetIntentFromDiscordMember(discordUser).getClient();
+      const userId = client.credentials.userId;
+      return client.getProfileInfo(userId, "avatar_url").then((avatarUrl) => {
+        return {
+          avatar: avatarUrl.avatar_url,
+          avatar_change: false,
+        };
+      });
+    }).then(({avatar, avatar_change}) => {
+      if (avatar_change || remoteUser.get("displayname") !== displayName) {
         // iterate over guilds and do the stuff right
-        const avatar = remoteUser.get("avatarurl");
         const client = this.GetIntentFromDiscordMember(discordUser).getClient();
         const userId = client.credentials.userId;
         const updates = [];


### PR DESCRIPTION
When a user on the discord side changes the username now, the nicknames are only in the bridged rooms updated where there isn't a separate guild nickname override