### PR TITLE
Soru/usernamefix

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "getbotlink": "node ./build/tools/addbot.js",
     "adminme": "node ./build/tools/adminme.js",
     "usertool": "node ./build/tools/userClientTools.js",
-    "directoryfix": "node ./build/tools/addRoomsToDirectory.js"
+    "directoryfix": "node ./build/tools/addRoomsToDirectory.js",
+    "ghostfix": "node ./build/tools/ghostfix.js"
   },
   "repository": {
     "type": "git",

--- a/src/matrixroomhandler.ts
+++ b/src/matrixroomhandler.ts
@@ -87,7 +87,11 @@ export class MatrixRoomHandler {
             return this.discord.UserSyncroniser.OnUpdateUser(member.user);
         }).then(() => {
             log.info("OnAliasQueried", `Joining ${member.id} to ${roomId}`);
-            return this.joinRoom(this.discord.GetIntentFromDiscordMember(member), roomId);
+            return this.joinRoom(this.discord.GetIntentFromDiscordMember(member), roomId)
+                .then(() => {
+                  // set the correct discord guild name
+                  this.discord.UserSyncroniser.EnsureJoin(member, roomId);
+                });
         }));
         delay += this.config.limits.roomGhostJoinDelay;
     }

--- a/test/test_matrixroomhandler.ts
+++ b/test/test_matrixroomhandler.ts
@@ -61,6 +61,7 @@ function createRH(opts: any = {}) {
     const us = {
         OnMemberState: () => Promise.resolve("user_sync_handled"),
         OnUpdateUser: () => Promise.resolve(),
+        EnsureJoin: () => Promise.resolve(),
     };
     const bot = {
         GetChannelFromRoomId: (roomid: string) => {

--- a/tools/ghostfix.ts
+++ b/tools/ghostfix.ts
@@ -1,0 +1,112 @@
+import { AppServiceRegistration, ClientFactory, Bridge } from "matrix-appservice-bridge";
+import * as yaml from "js-yaml";
+import * as fs from "fs";
+import * as args from "command-line-args";
+import * as usage from "command-line-usage";
+import * as log from "npmlog";
+import * as Bluebird from "bluebird";
+import { DiscordBridgeConfig } from "../src/config";
+import { DiscordBot } from "../src/bot";
+import { DiscordStore } from "../src/store";
+import { Provisioner } from "../src/provisioner";
+import { UserSyncroniser } from "../src/usersyncroniser";
+
+const optionDefinitions = [
+    {
+        name: "help",
+        alias: "h",
+        type: Boolean,
+        description: "Display this usage guide.",
+    },
+    {
+      name: "config",
+      alias: "c",
+      type: String,
+      defaultValue: "config.yaml",
+      description: "The AS config file.",
+      typeLabel: "<config.yaml>",
+    },
+];
+
+const options = args(optionDefinitions);
+
+if (options.help) {
+    /* tslint:disable:no-console */
+    console.log(usage([
+    {
+        header: "Fix usernames of joined ghosts",
+        content: "A tool to fix usernames of ghosts already in " +
+            "matrix rooms, to make sure they represent the correct discord usernames."},
+    {
+        header: "Options",
+        optionList: optionDefinitions,
+    },
+    ]));
+    process.exit(0);
+}
+
+const yamlConfig = yaml.safeLoad(fs.readFileSync("./discord-registration.yaml", "utf8"));
+const registration = AppServiceRegistration.fromObject(yamlConfig);
+const config: DiscordBridgeConfig = yaml.safeLoad(fs.readFileSync(options.config, "utf8")) as DiscordBridgeConfig;
+
+if (registration === null) {
+    throw new Error("Failed to parse registration file");
+}
+
+const botUserId = "@" + registration.sender_localpart + ":" + config.bridge.domain;
+const clientFactory = new ClientFactory({
+    appServiceUserId: botUserId,
+    token: registration.as_token,
+    url: config.bridge.homeserverUrl,
+});
+const provisioner = new Provisioner();
+const discordstore = new DiscordStore(config.database ? config.database.filename : "discord.db");
+const discordbot = new DiscordBot(config, discordstore, provisioner);
+
+const bridge = new Bridge({
+    clientFactory,
+    controller: {
+        onEvent: () => { },
+    },
+    intentOptions: {
+        clients: {
+            dontJoin: true, // handled manually
+      },
+    },
+    domain: config.bridge.domain,
+    homeserverUrl: config.bridge.homeserverUrl,
+    registration,
+    userStore: config.database.userStorePath,
+    roomStore: config.database.roomStorePath,
+});
+
+provisioner.SetBridge(bridge);
+discordbot.setBridge(bridge);
+let userSync;
+
+let client;
+bridge.loadDatabases().catch((e) => {
+    return discordstore.init();
+}).then(() => {
+    userSync = new UserSyncroniser(bridge, config, discordbot);
+    bridge._clientFactory = clientFactory;
+    return discordbot.ClientFactory.init().then(() => {
+        return discordbot.ClientFactory.getClient();
+    });
+}).then((clientTmp: any) => {
+    client = clientTmp;
+    const promiseList = [];
+    client.guilds.forEach((guild) => {
+        guild.members.forEach((member) => {
+            if (member.id === client.user.id) {
+                return;
+            }
+            promiseList.push(Bluebird.each(discordbot.GetRoomIdsFromGuild(guild.id), (room) => {
+                return userSync.EnsureJoin(member, room);
+            }));
+        });
+    });
+    return Bluebird.all(promiseList);
+}).then(() => {
+    process.exit(0);
+});


### PR DESCRIPTION
This makes sure that, when a new bridged room is created, the nickname is set correctly on the ghosts instead of username#hashtag being used.

It also provides a script to fix existing rooms