### PR TITLE
use correct name when mentioning

### DIFF
--- a/src/messageprocessor.ts
+++ b/src/messageprocessor.ts
@@ -141,7 +141,7 @@ export class MessageProcessor {
             const id = results[1];
             const member = msg.guild.members.get(id);
             const memberId = `@_discord_${id}:${this.opts.domain}`;
-            const memberStr = member ? member.user.username : memberId;
+            const memberStr = member ? (member.nickname ? member.nickname : member.user.username) : memberId;
             content = content.replace(results[0], memberStr);
             results = USER_REGEX.exec(content);
         }
@@ -156,7 +156,7 @@ export class MessageProcessor {
             const memberId = escapeHtml(`@_discord_${id}:${this.opts.domain}`);
             let memberName = memberId;
             if (member) {
-                memberName = escapeHtml(member.user.username);
+                memberName = escapeHtml(member.nickname ? member.nickname : member.user.username);
             }
             const memberStr = `<a href="${MATRIX_TO_LINK}${memberId}">${memberName}</a>`;
             content = content.replace(results[0], memberStr);

--- a/src/messageprocessor.ts
+++ b/src/messageprocessor.ts
@@ -141,7 +141,7 @@ export class MessageProcessor {
             const id = results[1];
             const member = msg.guild.members.get(id);
             const memberId = `@_discord_${id}:${this.opts.domain}`;
-            const memberStr = member ? (member.nickname ? member.nickname : member.user.username) : memberId;
+            const memberStr = member ? (member.displayName) : memberId;
             content = content.replace(results[0], memberStr);
             results = USER_REGEX.exec(content);
         }
@@ -156,7 +156,7 @@ export class MessageProcessor {
             const memberId = escapeHtml(`@_discord_${id}:${this.opts.domain}`);
             let memberName = memberId;
             if (member) {
-                memberName = escapeHtml(member.nickname ? member.nickname : member.user.username);
+                memberName = escapeHtml(member.displayName);
             }
             const memberStr = `<a href="${MATRIX_TO_LINK}${memberId}">${memberName}</a>`;
             content = content.replace(results[0], memberStr);

--- a/test/mocks/member.ts
+++ b/test/mocks/member.ts
@@ -5,10 +5,12 @@ export class MockMember {
   public id = "";
   public presence: Discord.Presence;
   public user: MockUser;
+  public nickname: string;
   constructor(id: string, username: string, public guild = null, public displayName: string = username) {
     this.id = id;
     this.presence = new Discord.Presence({});
     this.user = new MockUser(this.id, username);
+    this.nickname = displayName;
   }
 
   public MockSetPresence(presence: Discord.Presence) {

--- a/test/test_messageprocessor.ts
+++ b/test/test_messageprocessor.ts
@@ -156,6 +156,16 @@ describe("MessageProcessor", () => {
             content = processor.ReplaceMembers(content, msg);
             Chai.assert.equal(content, "Hello TestUsername");
         });
+        it("processes members with nickname correctly", () => {
+            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), <DiscordBot> bot);
+            const guild: any = new MockGuild("123", []);
+            guild._mockAddMember(new MockMember("12345", "TestUsername", null, "TestNickname"));
+            const channel = new Discord.TextChannel(guild, null);
+            const msg = new Discord.Message(channel, null, null);
+            let content = "Hello <@!12345>";
+            content = processor.ReplaceMembers(content, msg);
+            Chai.assert.equal(content, "Hello TestNickname");
+        });
     });
     describe("ReplaceMembersPostmark", () => {
         it("processes members missing from the guild correctly", () => {


### PR DESCRIPTION
Problem: When mentioning a user on discord who has a nickname set the created pill on the riot side contained their username, not their nickname

This problem wasn't visible in desktop riot due to desktop riot ignoring what the actual contents were, however, it is very visible on android riot