### PR TITLE
Assorted Dockerfile fixes and improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,4 +12,3 @@ README.md
 test
 docs
 config.yaml
-tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,8 @@ RUN apk add --no-cache -t build-deps make gcc g++ python ca-certificates libc-de
     && mv node_modules / \
     && cd / \
     && rm -rf /tmp/* \
-    && apk del build-deps
+    && apk del build-deps \
+    && sh -c 'cd /build/tools; for TOOL in *.js; do LINK="/usr/bin/$(basename $TOOL .js)"; echo -e "#/bin/sh\nnode /build/tools/$TOOL \$@" > $LINK; chmod +x $LINK; done'
 
 ENV NODE_ENV=production
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,4 @@ CMD node /build/discordas.js -p 9005 -c /data/config.yaml -f /data/discord-regis
 
 EXPOSE 9005
 VOLUME ["/data"]
+WORKDIR "/data"

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apk add --no-cache -t build-deps make gcc g++ python ca-certificates libc-de
 
 ENV NODE_ENV=production
 
-CMD node /build/discordas.js -p 9005 -c /data/config.yaml -f /data/discord-registration.yaml
+CMD node /build/src/discordas.js -p 9005 -c /data/config.yaml -f /data/discord-registration.yaml
 
 EXPOSE 9005
 VOLUME ["/data"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache -t build-deps make gcc g++ python ca-certificates libc-de
     && cd / \
     && rm -rf /tmp/* \
     && apk del build-deps \
-    && sh -c 'cd /build/tools; for TOOL in *.js; do LINK="/usr/bin/$(basename $TOOL .js)"; echo -e "#/bin/sh\nnode /build/tools/$TOOL \$@" > $LINK; chmod +x $LINK; done'
+    && sh -c 'cd /build/tools; for TOOL in *.js; do LINK="/usr/bin/$(basename $TOOL .js)"; echo -e "#!/bin/sh\nnode /build/tools/$TOOL \$@" > $LINK; chmod +x $LINK; done'
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
See #205 

* Remove `tools` directory from `.dockerignore` so it's included in the image
* Add links to all tools on the `PATH`, such that they can be executed with `docker exec`
* Set `WORKDIR` to `/data` so the tools will work correctly
* Correct path of the `discordas.js` in the `CMD`