### PR TITLE
Discord-side moderation of matrix users

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -13,6 +13,7 @@ import * as log from "npmlog";
 import * as Bluebird from "bluebird";
 import * as mime from "mime";
 import { Provisioner } from "./provisioner";
+import { MatrixRoomHandler } from "./matrixroomhandler";
 import {UserSyncroniser} from "./usersyncroniser";
 
 // Due to messages often arriving before we get a response from the send call,
@@ -39,6 +40,7 @@ export class DiscordBot {
   private mxEventProcessor: MatrixEventProcessor;
   private presenceHandler: PresenceHandler;
   private userSync: UserSyncroniser;
+  private roomHandler: MatrixRoomHandler;
 
   constructor(config: DiscordBridgeConfig, store: DiscordStore, private provisioner: Provisioner) {
     this.config = config;
@@ -56,6 +58,10 @@ export class DiscordBot {
     this.mxEventProcessor = new MatrixEventProcessor(
         new MatrixEventProcessorOpts(this.config, bridge),
     );
+  }
+
+  public setRoomHandler(roomHandler: MatrixRoomHandler) {
+    this.roomHandler = roomHandler;
   }
 
   get ClientFactory(): DiscordClientFactory {
@@ -479,7 +485,7 @@ export class DiscordBot {
 
     // check if it is a command to process by the bot itself
     if (msg.content.startsWith("!matrix")) {
-      await this.provisioner.HandleDiscordCommand(msg);
+      await this.roomHandler.HandleDiscordCommand(msg);
       return;
     }
 

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -335,7 +335,7 @@ export class DiscordBot {
     });
   }
 
-  private GetRoomIdsFromChannel(channel: Discord.Channel): Promise<string[]> {
+  public GetRoomIdsFromChannel(channel: Discord.Channel): Promise<string[]> {
     return this.bridge.getRoomStore().getEntriesByRemoteRoomData({
         discord_channel: channel.id,
     }).then((rooms) => {
@@ -475,6 +475,12 @@ export class DiscordBot {
       }
 
       return; // stop processing - we're approving/declining the bridge request
+    }
+
+    // check if it is a command to process by the bot itself
+    if (msg.content.startsWith("!matrix")) {
+      await this.provisioner.HandleDiscordCommand(msg);
+      return;
     }
 
     // Update presence because sometimes discord misses people.

--- a/src/discordas.ts
+++ b/src/discordas.ts
@@ -85,6 +85,7 @@ function run (port: number, fileConfig: DiscordBridgeConfig) {
   provisioner.SetBridge(bridge);
   roomhandler.setBridge(bridge);
   discordbot.setBridge(bridge);
+  provisioner.SetDiscordbot(discordbot);
   log.info("discordas", "Initing bridge.");
   log.info("AppServ", "Started listening on port %s at %s", port, new Date().toUTCString() );
   bridge.run(port, config).then(() => {

--- a/src/discordas.ts
+++ b/src/discordas.ts
@@ -85,7 +85,7 @@ function run (port: number, fileConfig: DiscordBridgeConfig) {
   provisioner.SetBridge(bridge);
   roomhandler.setBridge(bridge);
   discordbot.setBridge(bridge);
-  provisioner.SetDiscordbot(discordbot);
+  discordbot.setRoomHandler(roomhandler);
   log.info("discordas", "Initing bridge.");
   log.info("AppServ", "Started listening on port %s at %s", port, new Date().toUTCString() );
   bridge.run(port, config).then(() => {

--- a/src/matrixroomhandler.ts
+++ b/src/matrixroomhandler.ts
@@ -386,7 +386,6 @@ export class MatrixRoomHandler {
     return Promise.reject({err: "Unsupported", code: HTTP_UNSUPPORTED});
   }
 
-  
   public async HandleDiscordCommand(msg: Discord.Message) {
     if (!msg.member.hasPermission("ADMINISTRATOR")) {
       msg.channel.sendMessage("**ERROR:** insufficiant permissions to use matrix commands");

--- a/src/matrixroomhandler.ts
+++ b/src/matrixroomhandler.ts
@@ -378,7 +378,7 @@ export class MatrixRoomHandler {
 
   public async HandleDiscordCommand(msg: Discord.Message) {
     if (!(<Discord.TextChannel> msg.channel).guild) {
-      msg.channel.sendMessage("**ERROR:** only available for guild channels");
+      msg.channel.send("**ERROR:** only available for guild channels");
     }
     
     const {command, args} = Util.MsgToArgs(msg.content, "!matrix");
@@ -445,7 +445,7 @@ export class MatrixRoomHandler {
     }
     
     if (!msg.member.hasPermission(actions[command].permission as any)) {
-      msg.channel.sendMessage("**ERROR:** insufficiant permissions to use this matrix command");
+      msg.channel.send("**ERROR:** insufficiant permissions to use this matrix command");
       return;
     }
     

--- a/src/matrixroomhandler.ts
+++ b/src/matrixroomhandler.ts
@@ -386,6 +386,140 @@ export class MatrixRoomHandler {
     return Promise.reject({err: "Unsupported", code: HTTP_UNSUPPORTED});
   }
 
+  
+  public async HandleDiscordCommand(msg: Discord.Message) {
+    if (!msg.member.hasPermission("ADMINISTRATOR")) {
+      msg.channel.sendMessage("**ERROR:** insufficiant permissions to use matrix commands");
+      return;
+    }
+    if (!(<Discord.TextChannel> msg.channel).guild) {
+      msg.channel.sendMessage("**ERROR:** only available for guild channels");
+    }
+    const prefix = "!matrix ";
+    let command = "help";
+    let args = [];
+    if (msg.content.length >= prefix.length) {
+      const allArgs = msg.content.substring(prefix.length).split(" ");
+      if (allArgs.length && allArgs[0] !== "") {
+        command = allArgs[0];
+        allArgs.splice(0, 1);
+        args = allArgs;
+      }
+    }
+    
+    let replyMessage = "Error, unkown command. Try `!matrix help` to see all commands";
+    
+    const intent = this.bridge.getIntent();
+    const doAction = async (funcKey, action) => {
+      const name = args.join(" ");
+      const channels = await this.discord.GetRoomIdsFromChannel(msg.channel);
+      try {
+        const userMxid = await this.GetMxidFromName(name, channels);
+        let allChannels = [];
+        /* tslint:disable:await-promise */
+        await Bluebird.all((<Discord.TextChannel> msg.channel).guild.channels.map((c) => {
+        /* tslint:enable:await-promise */
+          return this.discord.GetRoomIdsFromChannel(c).then((chans) => {
+            allChannels = allChannels.concat(chans);
+          }).catch((e) => {
+            // pass, non-text-channel
+          });
+        }));
+        let errorMsg = "";
+        /* tslint:disable:await-promise */
+        await Bluebird.all(allChannels.map((c) => {
+        /* tslint:enable:await-promise */
+          return intent[funcKey](c, userMxid).catch((e) => {
+            // maybe we don't have permission to kick/ban/unban...?
+            errorMsg += `\nCouldn't ${funcKey} ${userMxid} from ${c}`;
+          });
+        }));
+        if (errorMsg) {
+          throw Error(errorMsg);
+        }
+        replyMessage = `${action} ${userMxid}`;
+      } catch (e) {
+        replyMessage = "**Error:** " + e.message;
+      }
+    };
+    
+    switch (command) {
+      case "help":
+        replyMessage = "Available Messages:\n" +
+            " - `!matrix kick <name>`: Kicks a user on the matrix side\n" +
+            " - `!matrix ban <name>`: Bans a user on the matrix side\n" +
+            " - `!matrix unban <name>`: Unbans a user on the matrix side\n\n" +
+            "The name must be the display name or the mxid of the user to perform the action on.";
+        break;
+      case "kick":
+        await doAction("kick", "Kicked");
+        break;
+      case "ban":
+        await doAction("ban", "Banned");
+        break;
+      case "unban":
+        await doAction("unban", "Unbanned");
+        break;
+      default:
+        break;
+    }
+    
+    msg.channel.send(replyMessage);
+  }
+
+  private async GetMxidFromName(name: string, channels: string[]) {
+    if (name[0] === "@" && name.includes(":")) {
+        return name;
+    }
+    const client = this.bridge.getIntent().getClient();
+    const matrixUsers = {};
+    let matches = 0;
+    /* tslint:disable:await-promise */
+    await Bluebird.all(channels.map((c) => {
+    /* tslint:enable:await-promise */
+      // we would use this.bridge.getBot().getJoinedMembers()
+      // but we also want to be able to search through banned members
+      // so we gotta roll our own thing
+      return client._http.authedRequestWithPrefix(
+        undefined, "GET", "/rooms/" + encodeURIComponent(c) + "/members",
+        undefined, undefined, "/_matrix/client/r0",
+      ).then((res) => {
+        res.chunk.forEach((member) => {
+          if (member.membership !== "join" && member.membership !== "ban") {
+            return;
+          }
+          const mxid = member.state_key;
+          if (mxid.startsWith("@_discord_")) {
+            return;
+          }
+          let displayName = member.content.displayname;
+          if (!displayName && member.unsigned && member.unsigned.prev_content &&
+            member.unsigned.prev_content.displayname) {
+            displayName = member.unsigned.prev_content.displayname;
+          }
+          if (!displayName) {
+            displayName = mxid.substring(1, mxid.indexOf(":"));
+          }
+          if (name.toLowerCase() === displayName.toLowerCase() || name === mxid) {
+            matrixUsers[mxid] = displayName;
+            matches++;
+          }
+        });
+      });
+    }));
+    if (matches === 0) {
+      throw Error(`No users matching ${name} found`);
+    }
+    if (matches > 1) {
+      let errStr = "Multiple matching users found:\n";
+      for (const mxid of Object.keys(matrixUsers)) {
+        errStr += `${matrixUsers[mxid]} (\`${mxid}\`)\n`;
+      }
+      throw Error(errStr);
+    }
+    return Object.keys(matrixUsers)[0];
+  }
+
   private joinRoom(intent: any, roomIdOrAlias: string): Promise<string> {
       let currentSchedule = JOIN_ROOM_SCHEDULE[0];
       const doJoin = () => Util.DelayedPromise(currentSchedule).then(() => intent.getClient().joinRoom(roomIdOrAlias));

--- a/src/provisioner.ts
+++ b/src/provisioner.ts
@@ -147,9 +147,9 @@ export class Provisioner {
         switch (command) {
             case "help":
                 replyMessage = "Available Messages:\n" +
-                    " - `kick <name>`: Kicks a user on the matrix side\n" +
-                    " - `ban <name>`: Bans a user on the matrix side\n" +
-                    " - `unban <name>`: Unbans a user on the matrix side\n\n" +
+                    " - `!matrix kick <name>`: Kicks a user on the matrix side\n" +
+                    " - `!matrix ban <name>`: Bans a user on the matrix side\n" +
+                    " - `!matrix unban <name>`: Unbans a user on the matrix side\n\n" +
                     "The name must be the display name or the mxid of the user to perform the action on.";
                 break;
             case "kick":

--- a/src/provisioner.ts
+++ b/src/provisioner.ts
@@ -4,7 +4,6 @@ import {
     MatrixRoom,
 } from "matrix-appservice-bridge";
 import * as Discord from "discord.js";
-import * as Bluebird from "bluebird";
 import { Permissions } from "discord.js";
 
 const PERMISSION_REQUEST_TIMEOUT = 300000; // 5 minutes

--- a/src/provisioner.ts
+++ b/src/provisioner.ts
@@ -131,8 +131,8 @@ export class Provisioner {
                 let errorMsg = "";
                 await Bluebird.all(allChannels.map((c) => {
                     return intent[funcKey](c, userMxid).catch((e) => {
-                        // maybe we don't have permission to kick...?
-                        errorMsg += `\nCouldn't kick ${userMxid} from ${c}`;
+                        // maybe we don't have permission to kick/ban/unban...?
+                        errorMsg += `\nCouldn't ${funcKey} ${userMxid} from ${c}`;
                     });
                 }));
                 if (errorMsg) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -10,8 +10,8 @@ const HTTP_OK = 200;
 
 export interface ICommandAction {
   params: string[];
-  description: string;
-  permission: string;
+  description?: string;
+  permission?: string;
   run(params: any): Promise<any>;
 };
 
@@ -20,7 +20,7 @@ export interface ICommandActions {
 };
 
 export interface ICommandParameter {
-  description: string;
+  description?: string;
   get(param: string): Promise<any>;
 };
 
@@ -206,7 +206,6 @@ export class Util {
     return Object.keys(matrixUsers)[0];
   }
 
-  
   public static async ParseCommand(action: ICommandAction, parameters: ICommandParameters, args: string[]) {
     if (action.params.length === 1) {
       args[0] = args.join(" ");

--- a/test/test_matrixroomhandler.ts
+++ b/test/test_matrixroomhandler.ts
@@ -658,5 +658,41 @@ describe("MatrixRoomHandler", () => {
                 expect(USERSKICKED).equals(0);
             });
         });
+        it("will ban a member", () => {
+            const handler: any = createRH({});
+            const channel = new MockChannel("123");
+            const guild = new MockGuild("456", [channel]);
+            channel.guild = guild;
+            const member: any = new MockMember("123456", "blah");
+            member.hasPermission = () => {
+                return true;
+            };
+            const message = {
+                channel,
+                member,
+                content: "!matrix ban someuser",
+            };
+            return handler.HandleDiscordCommand(message).then(() => {
+                expect(USERSBANNED).equals(1);
+            });
+        });
+        it("will unban a member", () => {
+            const handler: any = createRH({});
+            const channel = new MockChannel("123");
+            const guild = new MockGuild("456", [channel]);
+            channel.guild = guild;
+            const member: any = new MockMember("123456", "blah");
+            member.hasPermission = () => {
+                return true;
+            };
+            const message = {
+                channel,
+                member,
+                content: "!matrix unban someuser",
+            };
+            return handler.HandleDiscordCommand(message).then(() => {
+                expect(USERSUNBANNED).equals(1);
+            });
+        });
     });
 });

--- a/test/test_matrixroomhandler.ts
+++ b/test/test_matrixroomhandler.ts
@@ -36,7 +36,7 @@ const RoomHandler = (Proxyquire("../src/matrixroomhandler", {
 
 let USERSJOINED = 0;
 let USERSKICKED = 0;
-let USERSBANNED= 0;
+let USERSBANNED = 0;
 let USERSUNBANNED = 0;
 
 function buildRequest(eventData) {
@@ -52,7 +52,7 @@ function createRH(opts: any = {}) {
     log.level = "silent";
     USERSJOINED = 0;
     USERSKICKED = 0;
-    USERSBANNED= 0;
+    USERSBANNED = 0;
     USERSUNBANNED = 0;
     const bridge = {
         getIntent: () => {

--- a/test/test_matrixroomhandler.ts
+++ b/test/test_matrixroomhandler.ts
@@ -12,6 +12,7 @@ import {MockMember} from "./mocks/member";
 import * as Bluebird from "bluebird";
 import {MockGuild} from "./mocks/guild";
 import {Guild} from "discord.js";
+import { Util } from "../src/util";
 
 Chai.use(ChaiAsPromised);
 const expect = Chai.expect;
@@ -20,7 +21,23 @@ const expect = Chai.expect;
 //     "discord.js": { Client: require("./mocks/discordclient").MockDiscordClient },
 // }).DiscordClientFactory;
 
+const RoomHandler = (Proxyquire("../src/matrixroomhandler", {
+    "./util": {
+        Util: {
+            DelayedPromise: Util.DelayedPromise,
+            MsgToArgs: Util.MsgToArgs,
+            ParseCommand: Util.ParseCommand,
+            GetMxidFromName: () => {
+                return "@123456:localhost";
+            },
+        },
+    },
+})).MatrixRoomHandler;
+
 let USERSJOINED = 0;
+let USERSKICKED = 0;
+let USERSBANNED= 0;
+let USERSUNBANNED = 0;
 
 function buildRequest(eventData) {
     if (eventData.unsigned === undefined) {
@@ -34,6 +51,9 @@ function buildRequest(eventData) {
 function createRH(opts: any = {}) {
     log.level = "silent";
     USERSJOINED = 0;
+    USERSKICKED = 0;
+    USERSBANNED= 0;
+    USERSUNBANNED = 0;
     const bridge = {
         getIntent: () => {
             return {
@@ -41,6 +61,9 @@ function createRH(opts: any = {}) {
                 getClient: () => mxClient,
                 join: () => { USERSJOINED++; },
                 leave: () => { },
+                kick: () => { USERSKICKED++; return Promise.resolve(); },
+                ban: () => { USERSBANNED++; return Promise.resolve(); },
+                unban: () => { USERSUNBANNED++; return Promise.resolve(); },
             }; 
         },
         getBot: () => {
@@ -77,6 +100,9 @@ function createRH(opts: any = {}) {
             } else {
                 return Promise.reject("Roomid not found");
             }
+        },
+        GetRoomIdsFromChannel: (chan) => {
+            return Promise.resolve(["#" + chan.id + ":localhost"]);
         },
         GetBotId: () => "bot12345",
         ProcessMatrixRedact: () => Promise.resolve("redacted"),
@@ -133,7 +159,7 @@ function createRH(opts: any = {}) {
                 Promise.reject(new Error("Test failed unbridge")) : Promise.resolve();
         },
     };
-    const handler = new MatrixRoomHandler(bot as any, config, "@botuser:localhost", provisioner as any);
+    const handler = new RoomHandler(bot as any, config, "@botuser:localhost", provisioner as any);
     handler.setBridge(bridge);
     return handler;
 }
@@ -574,6 +600,63 @@ describe("MatrixRoomHandler", () => {
             const roomOpts = handler.createMatrixRoom(channel, "#test:localhost");
             expect(roomOpts.creationOpts).to.exist;
             expect(roomOpts.remote).to.exist;
+        });
+    });
+    describe("HandleDiscordCommand", () => {
+        it("will kick a member", () => {
+            const handler: any = createRH({});
+            const channel = new MockChannel("123");
+            const guild = new MockGuild("456", [channel]);
+            channel.guild = guild;
+            const member: any = new MockMember("123456", "blah");
+            member.hasPermission = () => {
+                return true;
+            };
+            const message = {
+                channel,
+                member,
+                content: "!matrix kick someuser",
+            };
+            return handler.HandleDiscordCommand(message).then(() => {
+                expect(USERSKICKED).equals(1);
+            });
+        });
+        it("will kick a member in all guild rooms", () => {
+            const handler: any = createRH({});
+            const channel = new MockChannel("123");
+            const guild = new MockGuild("456", [channel, (new MockChannel("456"))]);
+            channel.guild = guild;
+            const member: any = new MockMember("123456", "blah");
+            member.hasPermission = () => {
+                return true;
+            };
+            const message = {
+                channel,
+                member,
+                content: "!matrix kick someuser",
+            };
+            return handler.HandleDiscordCommand(message).then(() => {
+                // tslint:disable-next-line:no-magic-numbers
+                expect(USERSKICKED).equals(2);
+            });
+        });
+        it("will deny permission", () => {
+            const handler: any = createRH({});
+            const channel = new MockChannel("123");
+            const guild = new MockGuild("456", [channel]);
+            channel.guild = guild;
+            const member: any = new MockMember("123456", "blah");
+            member.hasPermission = () => {
+                return false;
+            };
+            const message = {
+                channel,
+                member,
+                content: "!matrix kick someuser",
+            };
+            return handler.HandleDiscordCommand(message).then(() => {
+                expect(USERSKICKED).equals(0);
+            });
         });
     });
 });

--- a/test/test_util.ts
+++ b/test/test_util.ts
@@ -1,0 +1,44 @@
+import * as Chai from "chai";
+import * as ChaiAsPromised from "chai-as-promised";
+
+import { Util, ICommandAction, ICommandParameters } from "../src/util";
+
+Chai.use(ChaiAsPromised);
+const expect = Chai.expect;
+
+describe("Util", () => {
+	describe("MsgToArgs", () => {
+		it("parses arguments", () => {
+			const {command, args} = Util.MsgToArgs("!matrix command arg1 arg2", "!matrix");
+			Chai.assert.equal(command, "command");
+			Chai.assert.equal(args.length, 2);
+			Chai.assert.equal(args[0], "arg1");
+			Chai.assert.equal(args[1], "arg2");
+		});
+	});
+	describe("ParseCommand", () => {
+		it("parses commands", () => {
+			const action: ICommandAction = {
+				params: ["param1", "param2"],
+				run: async ({param1, param2}) => {
+					return `param1: ${param1}\nparam2: ${param2}`;
+				},
+			};
+			const parameters: ICommandParameters = {
+				param1: {
+					get: async (param: string) => {
+						return "param1_"+param;
+					},
+				},
+				param2: {
+					get: async (param: string) => {
+						return "param2_"+param;
+					},
+				},
+			};
+			return Util.ParseCommand(action, parameters, ["hello", "world"]).then((retStr) => {
+				expect(retStr).equal("param1: param1_hello\nparam2: param2_world");
+			});
+		});
+	});
+});

--- a/test/test_util.ts
+++ b/test/test_util.ts
@@ -7,38 +7,39 @@ Chai.use(ChaiAsPromised);
 const expect = Chai.expect;
 
 describe("Util", () => {
-	describe("MsgToArgs", () => {
-		it("parses arguments", () => {
-			const {command, args} = Util.MsgToArgs("!matrix command arg1 arg2", "!matrix");
-			Chai.assert.equal(command, "command");
-			Chai.assert.equal(args.length, 2);
-			Chai.assert.equal(args[0], "arg1");
-			Chai.assert.equal(args[1], "arg2");
-		});
-	});
-	describe("ParseCommand", () => {
-		it("parses commands", () => {
-			const action: ICommandAction = {
-				params: ["param1", "param2"],
-				run: async ({param1, param2}) => {
-					return `param1: ${param1}\nparam2: ${param2}`;
-				},
-			};
-			const parameters: ICommandParameters = {
-				param1: {
-					get: async (param: string) => {
-						return "param1_"+param;
-					},
-				},
-				param2: {
-					get: async (param: string) => {
-						return "param2_"+param;
-					},
-				},
-			};
-			return Util.ParseCommand(action, parameters, ["hello", "world"]).then((retStr) => {
-				expect(retStr).equal("param1: param1_hello\nparam2: param2_world");
-			});
-		});
-	});
+    describe("MsgToArgs", () => {
+        it("parses arguments", () => {
+            const {command, args} = Util.MsgToArgs("!matrix command arg1 arg2", "!matrix");
+            Chai.assert.equal(command, "command");
+            // tslint:disable-next-line:no-magic-numbers
+            Chai.assert.equal(args.length, 2);
+            Chai.assert.equal(args[0], "arg1");
+            Chai.assert.equal(args[1], "arg2");
+        });
+    });
+    describe("ParseCommand", () => {
+        it("parses commands", () => {
+            const action: ICommandAction = {
+                params: ["param1", "param2"],
+                run: async ({param1, param2}) => {
+                    return `param1: ${param1}\nparam2: ${param2}`;
+                },
+            };
+            const parameters: ICommandParameters = {
+                param1: {
+                    get: async (param: string) => {
+                        return "param1_" + param;
+                    },
+                },
+                param2: {
+                    get: async (param: string) => {
+                        return "param2_" + param;
+                    },
+                },
+            };
+            return Util.ParseCommand(action, parameters, ["hello", "world"]).then((retStr) => {
+                expect(retStr).equal("param1: param1_hello\nparam2: param2_world");
+            });
+        });
+    });
 });

--- a/test/test_util.ts
+++ b/test/test_util.ts
@@ -100,7 +100,7 @@ describe("Util", () => {
                 ],
             };
             const intent = CreateMockIntent(mockRooms);
-            expect(Util.GetMxidFromName(intent, "goodboy", ["abc"])).to.eventually.be.rejected;
+            return expect(Util.GetMxidFromName(intent, "goodboy", ["abc"])).to.eventually.be.rejected;
         });
         it("Errors on no member", () => {
             const mockRooms = {
@@ -113,7 +113,7 @@ describe("Util", () => {
                 ],
             };
             const intent = CreateMockIntent(mockRooms);
-            expect(Util.GetMxidFromName(intent, "badboy", ["abc"])).to.eventually.be.rejected;
+            return expect(Util.GetMxidFromName(intent, "badboy", ["abc"])).to.eventually.be.rejected;
         });
     });
 });


### PR DESCRIPTION
This PR allows admins of a discord guild to kick, ban and unban members on the matrix side.

`!matrix help` output:

```
Available Messages:
 - kick <name>: Kicks a user on the matrix side
 - ban <name>: Bans a user on the matrix side
 - unban <name>: Unbans a user on the matrix side

The name must be the display name or the mxid of the user to perform the action on.
```