### PR TITLE
Remove WORKDIR from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,3 @@ CMD node /build/src/discordas.js -p 9005 -c /data/config.yaml -f /data/discord-r
 
 EXPOSE 9005
 VOLUME ["/data"]
-WORKDIR "/data"


### PR DESCRIPTION
This should resolve #212 which, which I introduced myself in my earlier pull request. Sorry about that!

This does mean that you'll have to add `-c /data/config.yaml` when invoking the tools, since we're not in `/data` anymore. I'll see if I can figure out some way to get around that later.