### PR TITLE
CD to /data before running tool, so that discord-registration.yaml is found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apk add --no-cache -t build-deps make gcc g++ python ca-certificates libc-de
     && cd / \
     && rm -rf /tmp/* \
     && apk del build-deps \
-    && sh -c 'cd /build/tools; for TOOL in *.js; do LINK="/usr/bin/$(basename $TOOL .js)"; echo -e "#!/bin/sh\nnode /build/tools/$TOOL \$@" > $LINK; chmod +x $LINK; done'
+    && sh -c 'cd /build/tools; for TOOL in *.js; do LINK="/usr/bin/$(basename $TOOL .js)"; echo -e "#!/bin/sh\ncd /data;\nnode /build/tools/$TOOL \$@" > $LINK; chmod +x $LINK; done'
 
 ENV NODE_ENV=production
 


### PR DESCRIPTION
See #205 #212 

The tools do need to be run from `/data` so they can find the `discord-registration.yaml`.