### PR TITLE
Fix Discord users not invited to Matrix room

### DIFF
--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -165,7 +165,7 @@ export class UserSyncroniser {
         try {
             await tryState();
         } catch (e) {
-            if (e.errorcode !== "M_FORBIDDEN") {
+            if (e.errcode !== "M_FORBIDDEN") {
                 log.warn(`Failed to send state to ${roomId}`, e);
             } else {
                 log.warn(`User not in room ${roomId}, inviting`);


### PR DESCRIPTION
Issue: when you mark a room invite-only, no new Discord users join when they talk.

It's caused by a typo - `e.errorcode` doesn't exist. Due to that, `e.errorcode !== "M_FORBIDDEN"` is always true, so the branch is always taken and `EnsureJoin` (which would normally invite the user) is never called.

This fixes the typo.

Also see https://matrix.to/#/!qPNOnUsNsZrToFZqxB:half-shot.uk/$15330661076GVDLQ:potatofrom.space.