### PR TITLE
have puppet do deletions, if present

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -257,25 +257,19 @@ export class DiscordBot {
     }
     log.info(`Got redact request for ${event.redacts}`);
     log.verbose(`Event:`, event);
+    
     const storeEvent = await this.store.Get(DbEvent, {matrix_id: event.redacts + ";" + event.room_id});
+    
     if (!storeEvent.Result) {
       log.warn(`Could not redact because the event was not in the store.`);
       return;
     }
     log.info(`Redact event matched ${storeEvent.ResultCount} entries`);
     while (storeEvent.Next()) {
-      log.info(`Deleting discord msg ${storeEvent.DiscordId}`);
-      if (!this.bot.guilds.has(storeEvent.GuildId)) {
-        log.warn(`Could not redact because the guild could not be found.`);
-        return;
-      }
-      if (!this.bot.guilds.get(storeEvent.GuildId).channels.has(storeEvent.ChannelId)) {
-        log.warn(`Could not redact because the guild could not be found.`);
-        return;
-      }
-      const channel = <Discord.TextChannel> this.bot.guilds.get(storeEvent.GuildId)
-                      .channels.get(storeEvent.ChannelId);
-      const msg = await channel.fetchMessage(storeEvent.DiscordId);
+      const result = await this.LookupRoom(storeEvent.GuildId, storeEvent.ChannelId, event.sender);
+      const chan = result.channel;
+      
+      const msg = await chan.fetchMessage(storeEvent.DiscordId);
       try {
         await msg.delete();
         log.info(`Deleted message`);


### PR DESCRIPTION
Problem: If the matrix link bot on the discord side lacks the "manage messages" permissions, it is impossible to relay redacts over

While the PR doesn't solve that completely, if you have a puppeted account, it will delete the message via the puppet, and as you are allowed to delete your own messages that will still work