### PR TITLE
Use membership cache for EnsureJoin

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -60,6 +60,7 @@ export class DiscordBot {
     this.mxEventProcessor = new MatrixEventProcessor(
         new MatrixEventProcessorOpts(this.config, bridge),
     );
+    this.userSync = new UserSyncroniser(this.bridge, this.config, this);
   }
 
   public setRoomHandler(roomHandler: MatrixRoomHandler) {
@@ -99,8 +100,6 @@ export class DiscordBot {
         });
       });
       const jsLog = new Log("discord.js");
-      
-      this.userSync = new UserSyncroniser(this.bridge, this.config, this);
       client.on("userUpdate", (_, user) => this.userSync.OnUpdateUser(user));
       client.on("guildMemberAdd", (user) => this.userSync.OnAddGuildMember(user));
       client.on("guildMemberRemove", (user) =>  this.userSync.OnRemoveGuildMember(user));

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -511,7 +511,7 @@ export class DiscordBot {
       return;
     }
 
-    // Update presence because sometimes discord misses people.
+    // Ensure we have the latest profile for the user.
     this.userSync.OnUpdateUser(msg.author).then(() => {
       return this.GetRoomIdsFromChannel(msg.channel).catch((err) => {
         log.verbose("No bridged rooms to send message to. Oh well.");


### PR DESCRIPTION
For a bit of background, the membership cache is an exposed cache between the bridge lib and the bridge itself which allows us to peek in at who we think is already joined by what state events we've seen and what joins/leaves we've sent. 

This will also mean we don't set state in some cases which might change the per room custom profiles.