### PR TITLE
ignore embeds with same url as in body

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -581,7 +581,7 @@ export class DiscordBot {
                     await this.store.Insert(evt);
                 });
             });
-            if (msg.content !== null && msg.content !== "") {
+            if (msg.content !== null) {
                 const result = await this.msgProcessor.FormatDiscordMessage(msg);
                 await Util.AsyncForEach(rooms, async (room) => {
                     const trySend = async () => intent.sendMessage(room, {

--- a/src/messageprocessor.ts
+++ b/src/messageprocessor.ts
@@ -105,6 +105,9 @@ export class MessageProcessor {
             if (embed.title === undefined && embed.description === undefined) {
                 continue;
             }
+            if (this.isEmbedInBody(msg, embed)) {
+                continue;
+            }
             let embedContent = "\n\n----"; // Horizontal rule. Two to make sure the content doesn't become a title.
             const embedTitle = embed.url ? `[${embed.title}](${embed.url})` : embed.title;
             if (embedTitle) {
@@ -121,6 +124,9 @@ export class MessageProcessor {
     public InsertEmbedsPostmark(content: string, msg: Discord.Message): string {
         for (const embed of msg.embeds) {
             if (embed.title === undefined && embed.description === undefined) {
+                continue;
+            }
+            if (this.isEmbedInBody(msg, embed)) {
                 continue;
             }
             let embedContent = "<hr>"; // Horizontal rule. Two to make sure the content doesn't become a title.
@@ -235,6 +241,13 @@ export class MessageProcessor {
             results = EMOJI_REGEX_POSTMARK.exec(content);
         }
         return content;
+    }
+
+    private isEmbedInBody(msg: Discord.Message, embed: Discord.MessageEmbed): boolean {
+        if (!embed.url) {
+            return false;
+        }
+        return msg.content.includes(embed.url);
     }
 }
 

--- a/test/test_messageprocessor.ts
+++ b/test/test_messageprocessor.ts
@@ -101,6 +101,36 @@ describe("MessageProcessor", () => {
             Chai.assert.equal(result.formattedBody, "<p>message</p><hr><h5><a href=\"http://example.com\">Title</a>" +
                 "</h5><p>Description</p>");
         });
+        it("should ignore same-url embeds", async () => {
+            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const msg = new MockMessage() as any;
+            msg.embeds = [
+                {
+                    author: {} as any,
+                    client: {} as any,
+                    color: {} as any,
+                    createdAt: {} as any,
+                    createdTimestamp: {} as any,
+                    description: "Description",
+                    fields: {} as any,
+                    footer: {} as any,
+                    hexColor: {} as any,
+                    image: {} as any,
+                    message: {} as any,
+                    provider: {} as any,
+                    thumbnail: {} as any,
+                    title: "Title",
+                    type: {} as any,
+                    url: "http://example.com",
+                    video: {} as any,
+                },
+            ];
+            msg.content = "message http://example.com";
+            const result = await processor.FormatDiscordMessage(msg);
+            Chai.assert.equal(result.body, "message http://example.com");
+            Chai.assert.equal(result.formattedBody, "<p>message <a href=\"http://example.com\">" +
+                "http://example.com</a></p>");
+        });
     });
     describe("FormatEdit", () => {
         it("should format basic edits appropriately", async () => {


### PR DESCRIPTION
This prevents discords auto-generated embed from URL previews to be transmitted to matrix, resulting in multiple matrix-sided url previews