### PR TITLE
make clear what EnsureJoin is about and re-write it to make it clear

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -607,7 +607,7 @@ export class DiscordBot {
                             log.error("DiscordBot", "Failed to send message into room.", e);
                             return;
                         }
-                        await this.userSync.EnsureJoin(msg.member, room);
+                        await this.userSync.JoinRoom(msg.member, room);
                         res = await trySend();
                         await afterSend(res);
                     }

--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -147,7 +147,8 @@ export class UserSyncroniser {
             await this.ApplyStateToRoom(state, roomId, member.guild.id);
         } catch (e) {
             if (e.errcode !== "M_FORBIDDEN") {
-                log.warn(`Failed to join ${state.id} to ${roomId}`, e);
+                log.error(`Failed to join ${state.id} to ${roomId}`, e);
+                throw e;
             } else {
                 log.info(`User not in room ${roomId}, inviting`);
                 try {
@@ -155,6 +156,7 @@ export class UserSyncroniser {
                     await this.ApplyStateToRoom(state, roomId, member.guild.id);
                 } catch (e) {
                     log.error(`Failed to join ${state.id} to ${roomId}`, e);
+                    throw e;
                 }
             }
         }

--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -58,6 +58,7 @@ export interface IGuildMemberState {
  */
 export class UserSyncroniser {
 
+    public static readonly ERR_NO_ERROR = "";
     public static readonly ERR_USER_NOT_FOUND = "user_not_found";
     public static readonly ERR_CHANNEL_MEMBER_NOT_FOUND = "channel_or_member_not_found";
     public static readonly ERR_NEWER_EVENT = "newer_state_event_arrived";
@@ -289,7 +290,7 @@ export class UserSyncroniser {
         log.info(`Got update for ${oldMember.id}.`);
         const state = await this.GetUserStateForGuildMember(newMember, oldMember.displayName);
         const rooms = await this.discord.GetRoomIdsFromGuild(newMember.guild.id);
-        return Promise.all(
+        await Promise.all(
             rooms.map(
                 async (roomId) => this.ApplyStateToRoom(state, roomId, newMember.guild.id),
             ),
@@ -346,7 +347,7 @@ export class UserSyncroniser {
         }
         const state = await this.GetUserStateForGuildMember(member, ev.content!.displayname);
         await this.ApplyStateToRoom(state, roomId, member.guild.id);
-        return "";
+        return UserSyncroniser.ERR_NO_ERROR;
     }
 
     private async memberStateLock(ev: IMatrixEvent, delayMs: number = -1): Promise<boolean> {

--- a/test/test_matrixroomhandler.ts
+++ b/test/test_matrixroomhandler.ts
@@ -87,7 +87,7 @@ function createRH(opts: any = {}) {
         },
     };
     const us = {
-        EnsureJoin: async () => { },
+        JoinRoom: async () => { USERSJOINED++; },
         OnMemberState: async () => {
             USERSYNC_HANDLED = true;
         },
@@ -155,6 +155,7 @@ function createRH(opts: any = {}) {
         getStateEvent: async () => {
             return opts.powerLevels || {};
         },
+        getUserId: () => "@user:localhost",
         joinRoom: async () => {
             USERSJOINED++;
         },

--- a/tools/ghostfix.ts
+++ b/tools/ghostfix.ts
@@ -130,7 +130,7 @@ async function run() {
                             let currentSchedule = JOIN_ROOM_SCHEDULE[0];
                             const doJoin = async () => {
                                 await Util.DelayedPromise(currentSchedule);
-                                await userSync.EnsureJoin(member, room);
+                                await userSync.JoinRoom(member, room);
                             };
                             const errorHandler = async (err) => {
                                 log.error(`Error joining room ${room} as ${member.id}`);


### PR DESCRIPTION
Removes `EnsureJoin` and splits it up to `JoinRoom` and `SetRoomState`.

`JoinRoom` is meant to, well, join a user to a room, on a basic level (it handles inviting, if needed, and also sets all the custom `m.member` keys, which is why matrixroomhadnlers `joinRoom` function (the one with the join scheduler) uses this now)

`SetRoomState` is meant for updating the custom `m.member` keys, e.g. on role changes (not implemented yet, thus currently unused).

This should show that #246 kinda is unneeded, and should also clarify / close #230