### PR TITLE
Update usersynchroniser to handle more things

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -159,8 +159,8 @@ export class DiscordBot {
         client.on("userUpdate", async (_, user) => this.userSync.OnUpdateUser(user));
         client.on("guildMemberAdd", async (user) => this.userSync.OnAddGuildMember(user));
         client.on("guildMemberRemove", async (user) =>  this.userSync.OnRemoveGuildMember(user));
-        client.on("guildMemberUpdate", async (oldUser, newUser) =>
-            this.userSync.OnUpdateGuildMember(oldUser, newUser));
+        client.on("guildMemberUpdate", async (_, member) =>
+            this.userSync.OnUpdateGuildMember(member));
         client.on("debug", (msg) => { jsLog.verbose(msg); });
         client.on("error", (msg) => { jsLog.error(msg); });
         client.on("warn", (msg) => { jsLog.warn(msg); });

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -439,10 +439,12 @@ export class DiscordBot {
         if (member) {
             let rooms: string[] = [];
             await Util.AsyncForEach(guild.channels.array(), async (channel) => {
-                if (!channel.members.has(member.id)) {
+                if (channel.type !== "text" || !channel.members.has(member.id)) {
                     return;
                 }
-                rooms = rooms.concat(await this.channelSync.GetRoomIdsFromChannel(channel));
+                try {
+                    rooms = rooms.concat(await this.channelSync.GetRoomIdsFromChannel(channel));
+                } catch (e) { } // no bridged rooms for this channel
             });
             if (rooms.length === 0) {
                 log.verbose(`Couldn't find room(s) for guild id:${guild.id} with member id:${member.id}.`);

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -76,6 +76,7 @@ export class DiscordBot {
         this.mxEventProcessor = new MatrixEventProcessor(
             new MatrixEventProcessorOpts(this.config, bridge, this),
         );
+        this.channelSync = new ChannelSyncroniser(this.bridge, this.config, this);
     }
 
     public setRoomHandler(roomHandler: MatrixRoomHandler) {
@@ -111,7 +112,6 @@ export class DiscordBot {
                 this.presenceHandler.EnqueueUser(newMember.user);
             });
         }
-        this.channelSync = new ChannelSyncroniser(this.bridge, this.config, this);
         client.on("channelUpdate", async (_, newChannel) => this.channelSync.OnUpdate(newChannel) );
         client.on("channelDelete", async (channel) => this.channelSync.OnDelete(channel) );
         client.on("guildUpdate", async (_, newGuild) => this.channelSync.OnGuildUpdate(newGuild) );

--- a/src/channelsyncroniser.ts
+++ b/src/channelsyncroniser.ts
@@ -123,6 +123,9 @@ export class ChannelSyncroniser {
     }
 
     public async GetRoomIdsFromChannel(channel: Discord.Channel): Promise<string[]> {
+        if (!this.roomStore) {
+            this.roomStore = this.bridge.getRoomStore();
+        }
         const rooms = await this.roomStore.getEntriesByRemoteRoomData({
             discord_channel: channel.id,
         });
@@ -140,6 +143,9 @@ export class ChannelSyncroniser {
             mxChannels: [],
         });
 
+        if (!this.roomStore) {
+            this.roomStore = this.bridge.getRoomStore();
+        }
         const remoteRooms = await this.roomStore.getEntriesByRemoteRoomData({discord_channel: channel.id});
         if (remoteRooms.length === 0) {
             log.verbose(`Could not find any channels in room store.`);

--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -272,7 +272,7 @@ export class UserSyncroniser {
     }
 
     public async OnUpdateGuildMember(member: GuildMember, doJoin: boolean = false) {
-        log.info(`Got update for ${member.id}.`);
+        log.info(`Got update for ${member.id} (${member.user.username}).`);
         const state = await this.GetUserStateForGuildMember(member);
         let wantRooms: string[] = [];
         try {

--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -309,12 +309,12 @@ export class UserSyncroniser {
                 },
             ),
         );
+        const userId = state.mxUserId;
+        const intent = this.bridge.getIntent(userId);
         await Promise.all(
             leaveRooms.map(
                 async (roomId) => {
                     try {
-                        const userId = state.mxUserId;
-                        const intent = this.bridge.getIntent(userId);
                         if ([null, "join", "invite"]
                             .includes(intent.opts.backingStore.getMembership(roomId, state.mxUserId))) {
                             await intent.leave(roomId);

--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -256,20 +256,13 @@ export class UserSyncroniser {
 
     public async OnAddGuildMember(member: GuildMember) {
         log.info(`Joining ${member.id} to all rooms for guild ${member.guild.id}`);
-        const rooms = await this.discord.GetRoomIdsFromGuild(member.guild, member);
-        const intent = this.discord.GetIntentFromDiscordMember(member);
-        await this.OnUpdateUser(member.user);
-        return Promise.all(
-            rooms.map(
-                (roomId) => intent.join(roomId),
-            ),
-        );
+        await this.OnUpdateGuildMember(member, true);
     }
 
     public async OnRemoveGuildMember(member: GuildMember) {
         /* NOTE: This can be because of a kick, ban or the user just leaving. Discord doesn't tell us. */
         log.info(`Leaving ${member.id} to all rooms for guild ${member.guild.id}`);
-        const rooms = await this.discord.GetRoomIdsFromGuild(member.guild, member);
+        const rooms = await this.discord.GetRoomIdsFromGuild(member.guild);
         const intent = this.discord.GetIntentFromDiscordMember(member);
         return Promise.all(
             rooms.map(

--- a/test/mocks/member.ts
+++ b/test/mocks/member.ts
@@ -1,4 +1,6 @@
+import {MockCollection} from "./collection";
 import {MockUser} from "./user";
+import {MockRole} from "./role";
 import * as Discord from "discord.js";
 
 // we are a test file and thus need those
@@ -9,7 +11,7 @@ export class MockMember {
     public presence: Discord.Presence;
     public user: MockUser;
     public nickname: string;
-    public roles: any[] = [];
+    public roles = new MockCollection<string, MockRole>();
     constructor(id: string, username: string, public guild: any = null, public displayName: string = username) {
         this.id = id;
         this.presence = new Discord.Presence({}, {} as any);

--- a/test/mocks/role.ts
+++ b/test/mocks/role.ts
@@ -2,5 +2,5 @@
 // we are a test file and thus need those
 /* tslint:disable:no-unused-expression max-file-line-count no-any */
 export class MockRole {
-    constructor(public id: string = "", public name = "", public color = 0) { }
+    constructor(public id: string = "", public name = "", public color = 0, public position = 0) { }
 }

--- a/test/test_usersyncroniser.ts
+++ b/test/test_usersyncroniser.ts
@@ -511,16 +511,12 @@ describe("UserSyncroniser", () => {
             const userSync = CreateUserSync([new RemoteUser("123456")]);
             const guild = new MockGuild(
                 "654321");
-            const oldMember = new MockMember(
-                "123456",
-                "username",
-                guild);
             const newMember = new MockMember(
                 "123456",
                 "username",
                 guild,
                 "FiddleDee");
-            await userSync.OnUpdateGuildMember(oldMember as any, newMember as any);
+            await userSync.OnUpdateGuildMember(newMember as any);
             expect(SEV_COUNT).to.equal(GUILD_ROOM_IDS.length);
         });
     });

--- a/test/test_usersyncroniser.ts
+++ b/test/test_usersyncroniser.ts
@@ -67,6 +67,7 @@ function CreateUserSync(remoteUsers: any[] = []): UserSyncroniser {
             return {
                 getClient: () => {
                     return {
+                        getUserId: () => "@user:localhost",
                         sendStateEvent: (roomId, type, content, key) => {
                             SEV_ROOM_ID = roomId;
                             SEV_CONTENT = content;
@@ -86,6 +87,7 @@ function CreateUserSync(remoteUsers: any[] = []): UserSyncroniser {
                 opts: {
                     backingStore: {
                         getMembership: (roomId, userId) => "join",
+                        setMembership: (roomId, userId, membership) => { },
                     },
                 },
                 setAvatarUrl: async (ava) => {

--- a/test/test_usersyncroniser.ts
+++ b/test/test_usersyncroniser.ts
@@ -9,6 +9,7 @@ import {MockMember} from "./mocks/member";
 import {MockGuild} from "./mocks/guild";
 import { MockChannel } from "./mocks/channel";
 import { IMatrixEvent } from "../src/matrixtypes";
+import { Util } from "../src/util";
 
 // we are a test file and thus need those
 /* tslint:disable:no-unused-expression max-file-line-count no-any */
@@ -38,6 +39,7 @@ const GUILD_ROOM_IDS = ["!abc:localhost", "!def:localhost", "!ghi:localhost"];
 const UserSync = (Proxyquire("../src/usersyncroniser", {
     "./util": {
         Util: {
+            AsyncForEach: Util.AsyncForEach,
             UploadContentFromUrl: async () => {
                 UTIL_UPLOADED_AVATAR = true;
                 return {mxcUrl: "avatarset"};
@@ -452,18 +454,6 @@ describe("UserSyncroniser", () => {
             const state = await userSync.GetUserStateForGuildMember(member as any);
             expect(state.displayName).to.be.equal("BestDog");
         });
-        it("Will not apply if the nick has already been set", async () => {
-            const userSync = CreateUserSync([new RemoteUser("123456")]);
-            const guild = new MockGuild(
-                "654321");
-            const member = new MockMember(
-                "123456",
-                "username",
-                guild,
-                "BestDog");
-            const state = await userSync.GetUserStateForGuildMember(member as any, "BestDog");
-            expect(state.displayName).is.empty;
-        });
         it("Will correctly add roles", async () => {
             const userSync = CreateUserSync([new RemoteUser("123456")]);
             const guild = new MockGuild(
@@ -532,23 +522,6 @@ describe("UserSyncroniser", () => {
                 "FiddleDee");
             await userSync.OnUpdateGuildMember(oldMember as any, newMember as any);
             expect(SEV_COUNT).to.equal(GUILD_ROOM_IDS.length);
-        });
-        it("will not update state for unchanged member", async () => {
-            const userSync = CreateUserSync([new RemoteUser("123456")]);
-            const guild = new MockGuild(
-                "654321");
-            const oldMember = new MockMember(
-                "123456",
-                "username",
-                guild,
-                "FiddleDee");
-            const newMember = new MockMember(
-                "123456",
-                "username",
-                guild,
-                "FiddleDee");
-            await userSync.OnUpdateGuildMember(oldMember as any, newMember as any);
-            expect(SEV_COUNT).to.equal(0);
         });
     });
     describe("OnMemberState", () => {

--- a/test/test_usersyncroniser.ts
+++ b/test/test_usersyncroniser.ts
@@ -495,7 +495,7 @@ describe("UserSyncroniser", () => {
                 "username",
                 guild);
             await userSync.OnAddGuildMember(member as any);
-            expect(JOINS).to.equal(GUILD_ROOM_IDS.length);
+            expect(SEV_COUNT).to.equal(GUILD_ROOM_IDS.length);
         });
     });
     describe("OnRemoveGuildMember", () => {

--- a/tools/chanfix.ts
+++ b/tools/chanfix.ts
@@ -94,7 +94,6 @@ async function run() {
     } catch (e) {
         await discordstore.init();
     }
-    const chanSync = new ChannelSyncroniser(bridge, config, discordbot);
     bridge._clientFactory = clientFactory;
     bridge._botClient = bridge._clientFactory.getClientAs();
     bridge._botIntent = new Intent(bridge._botClient, bridge._botClient, { registered: true });
@@ -129,7 +128,7 @@ async function run() {
         promiseList2.push((async () => {
             await Bluebird.delay(curDelay);
             try {
-                await chanSync.OnGuildUpdate(guild, true);
+                await discordbot.ChannelSyncroniser.OnGuildUpdate(guild, true);
             } catch (err) {
                 log.warn(`Couldn't update rooms of guild ${guild.id}`, err);
             }

--- a/tools/ghostfix.ts
+++ b/tools/ghostfix.ts
@@ -106,7 +106,6 @@ async function run() {
     } catch (e) {
         await discordstore.init();
     }
-    const chanSync = new ChannelSyncroniser(bridge, config, discordbot);
     const userSync = new UserSyncroniser(bridge, config, discordbot);
     bridge._clientFactory = clientFactory;
     await discordbot.ClientFactory.init();


### PR DESCRIPTION
Updates the custom `m.room.member` key on e.g. role changes (can't find an issue for this atm)

Only join rooms you are in  #219 

Handle role-based join / leaves #215


Test failing is, again, due to that one PR that will fix things