### PR TITLE
handles @room for M -> D

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -19,20 +19,11 @@ bridge:
   disablePresence: false
   # Disable sending typing notifications when somebody on Discord types.
   disableTypingNotifications: false
-  # Disable parsing discord usernames out of matrix messages so
-  # that it highlights discord users.
-  # WARNING: Not always 100% accurate, but close enough usually.
-  disableDiscordMentions: false
   # Disable deleting messages on Discord if a message is redacted on Matrix.
   disableDeletionForwarding: false
   # Enable users to bridge rooms using !discord commands. See
   # https://t2bot.io/discord for instructions.
   enableSelfServiceBridging: false
-  # For both below, a space is inserted after @ to stop the mentions working.
-  # Disable relaying @everyone to Discord. Non-puppeted users can abuse this.
-  disableEveryoneMention: false
-  # Disable relaying @here to Discord. Non-puppeted users can abuse this.
-  disableHereMention: false
 # Authentication configuration for the discord bot.
 auth:
   clientID: "12345"

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -16,15 +16,9 @@ properties:
             type: "boolean"
           disableTypingNotifications:
             type: "boolean"
-          disableDiscordMentions:
-            type: "boolean"
           disableDeletionForwarding:
             type: "boolean"
           enableSelfServiceBridging:
-            type: "boolean"
-          disableEveryoneMention:
-            type: "boolean"
-          disableHereMention:
             type: "boolean"
     auth:
         type: "object"

--- a/package-lock.json
+++ b/package-lock.json
@@ -726,7 +726,7 @@
       "version": "git+https://github.com/Sorunome/discord-markdown.git#8897770f5c84594b8ca2fec2c3efd7a5541d4224",
       "from": "git+https://github.com/Sorunome/discord-markdown.git",
       "requires": {
-        "highlight.js": "^9.12.0",
+        "highlight.js": "^9.13.1",
         "simple-markdown": "^0.4.2"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1374,8 +1374,7 @@
     "he": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-      "dev": true
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
     },
     "highlight.js": {
       "version": "9.13.1",
@@ -2062,6 +2061,14 @@
       "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
+    },
+    "node-html-parser": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-1.1.11.tgz",
+      "integrity": "sha512-KOjvmbk0yWuy/cN8uqk6bVYS0Lue+jVWcLO/zmnCtz8FPXhj00apBN376FoM6QmFMMbJwXQdKf5ko6G1S6bnrw==",
+      "requires": {
+        "he": "1.1.1"
+      }
     },
     "nopt": {
       "version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "matrix-appservice-bridge": "^1.7.0",
     "mime": "^1.6.0",
     "moment": "^2.22.2",
+    "node-html-parser": "^1.1.11",
     "pg-promise": "^8.5.1",
     "tslint": "^5.11.0",
     "typescript": "^3.1.3",

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -8,7 +8,7 @@ import { Util } from "./util";
 import {
     DiscordMessageProcessor,
     DiscordMessageProcessorOpts,
-    DiscordMessageProcessorMatrixResult,
+    DiscordMessageProcessorResult,
 } from "./discordmessageprocessor";
 import { MatrixEventProcessor, MatrixEventProcessorOpts } from "./matrixeventprocessor";
 import { PresenceHandler } from "./presencehandler";
@@ -451,7 +451,7 @@ export class DiscordBot {
         return rooms.map((room) => room.matrix.getId());
     }
 
-    private async SendMatrixMessage(matrixMsg: DiscordMessageProcessorMatrixResult, chan: Discord.Channel,
+    private async SendMatrixMessage(matrixMsg: DiscordMessageProcessorResult, chan: Discord.Channel,
                                     guild: Discord.Guild, author: Discord.User,
                                     msgID: string): Promise<boolean> {
         const rooms = await this.channelSync.GetRoomIdsFromChannel(chan);

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -276,15 +276,8 @@ export class DiscordBot {
         const result = await this.LookupRoom(guildId, channelId, event.sender);
         const chan = result.channel;
         const botUser = result.botUser;
-        let profile = null;
-        if (result.botUser) {
-            // We are doing this through webhooks so fetch the user profile.
-            profile = await mxClient.getStateEvent(event.room_id, "m.room.member", event.sender);
-            if (profile === null) {
-                log.warn(`User ${event.sender} has no member state. That's odd.`);
-            }
-        }
-        const embedSet = await this.mxEventProcessor.EventToEmbed(event, profile, chan);
+
+        const embedSet = await this.mxEventProcessor.EventToEmbed(event, chan);
         const embed = embedSet.messageEmbed;
         const opts: Discord.MessageOptions = {};
         const file = await this.mxEventProcessor.HandleAttachment(event, mxClient);

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -588,7 +588,7 @@ export class DiscordBot {
             if (msg.content === null) {
                 return;
             }
-            const result = await this.discordMsgProcessor.FormatDiscordMessage(msg);
+            const result = await this.discordMsgProcessor.FormatMessage(msg);
             if (!result.body) {
                 return;
             }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -439,6 +439,14 @@ export class DiscordBot {
         return dbEmoji.MxcUrl;
     }
 
+    public async GetEmojiByMxc(mxc: string): Promise<DbEmoji> {
+        const dbEmoji = await this.store.Get(DbEmoji, {mxc_url: mxc});
+        if (!dbEmoji || !dbEmoji.Result) {
+            throw new Error("Couldn't fetch from store");
+        }
+        return dbEmoji;
+    }
+
     public async GetRoomIdsFromGuild(guild: string): Promise<string[]> {
         const rooms = await this.bridge.getRoomStore().getEntriesByRemoteRoomData({
             discord_guild: guild,

--- a/src/db/dbdataemoji.ts
+++ b/src/db/dbdataemoji.ts
@@ -12,11 +12,19 @@ export class DbEmoji implements IDbData {
     public Result: boolean;
 
     public async RunQuery(store: DiscordStore, params: ISqlCommandParameters): Promise<void> {
-        const row = await store.db.Get(`
+        let query = `
             SELECT *
             FROM emoji
-            WHERE emoji_id = $id`, {
+            WHERE emoji_id = $id`;
+        if (params.mxc_url) {
+            query = `
+                SELECT *
+                FROM emoji
+                WHERE mxc_url = $mxc`;
+        }
+        const row = await store.db.Get(query, {
                 id: params.emoji_id,
+                mxc: params.mxc_url,
             });
         this.Result = row !== undefined;
         if (this.Result) {

--- a/src/discordmessageprocessor.ts
+++ b/src/discordmessageprocessor.ts
@@ -46,7 +46,7 @@ export class DiscordMessageProcessor {
         }
     }
 
-    public async FormatDiscordMessage(msg: Discord.Message): Promise<DiscordMessageProcessorMatrixResult> {
+    public async FormatMessage(msg: Discord.Message): Promise<DiscordMessageProcessorMatrixResult> {
         const result = new DiscordMessageProcessorMatrixResult();
 
         let content = msg.content;
@@ -81,7 +81,7 @@ export class DiscordMessageProcessor {
     ): Promise<DiscordMessageProcessorMatrixResult> {
         // TODO: Produce a nice, colored diff between the old and new message content
         oldMsg.content = `*edit:* ~~${oldMsg.content}~~ -> ${newMsg.content}`;
-        return this.FormatDiscordMessage(oldMsg);
+        return this.FormatMessage(oldMsg);
     }
 
     public InsertEmbeds(content: string, msg: Discord.Message): string {

--- a/src/discordmessageprocessor.ts
+++ b/src/discordmessageprocessor.ts
@@ -14,13 +14,13 @@ const ANIMATED_MXC_INSERT_REGEX_GROUP = 2;
 const ID_MXC_INSERT_REGEX_GROUP = 3;
 const EMOJI_SIZE = 32;
 
-export class MessageProcessorOpts {
+export class DiscordMessageProcessorOpts {
     constructor(readonly domain: string, readonly bot?: DiscordBot) {
 
     }
 }
 
-export class MessageProcessorMatrixResult {
+export class DiscordMessageProcessorMatrixResult {
     public formattedBody: string;
     public body: string;
     public msgtype: string;
@@ -35,19 +35,19 @@ interface IEmojiNode extends IDiscordNode {
     name: string;
 }
 
-export class MessageProcessor {
-    private readonly opts: MessageProcessorOpts;
-    constructor(opts: MessageProcessorOpts, bot: DiscordBot | null = null) {
+export class DiscordMessageProcessor {
+    private readonly opts: DiscordMessageProcessorOpts;
+    constructor(opts: DiscordMessageProcessorOpts, bot: DiscordBot | null = null) {
         // Backwards compat
         if (bot !== null) {
-            this.opts = new MessageProcessorOpts(opts.domain, bot);
+            this.opts = new DiscordMessageProcessorOpts(opts.domain, bot);
         } else {
             this.opts = opts;
         }
     }
 
-    public async FormatDiscordMessage(msg: Discord.Message): Promise<MessageProcessorMatrixResult> {
-        const result = new MessageProcessorMatrixResult();
+    public async FormatDiscordMessage(msg: Discord.Message): Promise<DiscordMessageProcessorMatrixResult> {
+        const result = new DiscordMessageProcessorMatrixResult();
 
         let content = msg.content;
 
@@ -75,7 +75,10 @@ export class MessageProcessor {
         return result;
     }
 
-    public async FormatEdit(oldMsg: Discord.Message, newMsg: Discord.Message): Promise<MessageProcessorMatrixResult> {
+    public async FormatEdit(
+        oldMsg: Discord.Message,
+        newMsg: Discord.Message,
+    ): Promise<DiscordMessageProcessorMatrixResult> {
         // TODO: Produce a nice, colored diff between the old and new message content
         oldMsg.content = `*edit:* ~~${oldMsg.content}~~ -> ${newMsg.content}`;
         return this.FormatDiscordMessage(oldMsg);

--- a/src/discordmessageprocessor.ts
+++ b/src/discordmessageprocessor.ts
@@ -5,7 +5,7 @@ import * as escapeHtml from "escape-html";
 import { Util } from "./util";
 
 import { Log } from "./log";
-const log = new Log("MessageProcessor");
+const log = new Log("DiscordMessageProcessor");
 
 const MATRIX_TO_LINK = "https://matrix.to/#/";
 const MXC_INSERT_REGEX = /\x01(\w+)\x01([01])\x01([0-9]*)\x01/g;
@@ -20,7 +20,7 @@ export class DiscordMessageProcessorOpts {
     }
 }
 
-export class DiscordMessageProcessorMatrixResult {
+export class DiscordMessageProcessorResult {
     public formattedBody: string;
     public body: string;
     public msgtype: string;
@@ -46,8 +46,8 @@ export class DiscordMessageProcessor {
         }
     }
 
-    public async FormatMessage(msg: Discord.Message): Promise<DiscordMessageProcessorMatrixResult> {
-        const result = new DiscordMessageProcessorMatrixResult();
+    public async FormatMessage(msg: Discord.Message): Promise<DiscordMessageProcessorResult> {
+        const result = new DiscordMessageProcessorResult();
 
         let content = msg.content;
 
@@ -78,7 +78,7 @@ export class DiscordMessageProcessor {
     public async FormatEdit(
         oldMsg: Discord.Message,
         newMsg: Discord.Message,
-    ): Promise<DiscordMessageProcessorMatrixResult> {
+    ): Promise<DiscordMessageProcessorResult> {
         // TODO: Produce a nice, colored diff between the old and new message content
         oldMsg.content = `*edit:* ~~${oldMsg.content}~~ -> ${newMsg.content}`;
         return this.FormatMessage(oldMsg);

--- a/src/matrixeventprocessor.ts
+++ b/src/matrixeventprocessor.ts
@@ -8,7 +8,7 @@ import * as mime from "mime";
 import { MatrixUser, Bridge } from "matrix-appservice-bridge";
 import { Client as MatrixClient } from "matrix-js-sdk";
 import { IMatrixEvent, IMatrixEventContent, IMatrixMessage } from "./matrixtypes";
-import { MatrixMessageProcessor, MatrixMessageProcessorOpts } from "./matrixmessageprocessor";
+import { MatrixMessageProcessor } from "./matrixmessageprocessor";
 
 import { Log } from "./log";
 const log = new Log("MatrixEventProcessor");
@@ -44,13 +44,7 @@ export class MatrixEventProcessor {
         this.config = opts.config;
         this.bridge = opts.bridge;
         this.discord = opts.discord;
-        this.matrixMsgProcessor = new MatrixMessageProcessor(
-            this.discord,
-            new MatrixMessageProcessorOpts(
-                this.config.bridge.disableEveryoneMention,
-                this.config.bridge.disableHereMention,
-            ),
-        );
+        this.matrixMsgProcessor = new MatrixMessageProcessor(this.discord);
     }
 
     public StateEventToMessage(event: IMatrixEvent, channel: Discord.TextChannel): string | undefined {

--- a/src/matrixeventprocessor.ts
+++ b/src/matrixeventprocessor.ts
@@ -1,5 +1,4 @@
 import * as Discord from "discord.js";
-import { MessageProcessorOpts, MessageProcessor } from "./messageprocessor";
 import { DiscordBot } from "./bot";
 import { DiscordBridgeConfig } from "./config";
 import * as escapeStringRegexp from "escape-string-regexp";

--- a/src/matrixeventprocessor.ts
+++ b/src/matrixeventprocessor.ts
@@ -8,7 +8,7 @@ import * as mime from "mime";
 import { MatrixUser, Bridge } from "matrix-appservice-bridge";
 import { Client as MatrixClient } from "matrix-js-sdk";
 import { IMatrixEvent, IMatrixEventContent, IMatrixMessage } from "./matrixtypes";
-import { MatrixMessageProcessor } from "./matrixmessageprocessor";
+import { MatrixMessageProcessor, IMatrixMessageProcessorParams } from "./matrixmessageprocessor";
 
 import { Log } from "./log";
 const log = new Log("MatrixEventProcessor");
@@ -102,9 +102,18 @@ export class MatrixEventProcessor {
             log.warn(`Trying to fetch member state or profile for ${event.sender} failed`, err);
         }
 
+        const params = {
+            mxClient,
+            roomId: event.room_id,
+            userId: event.sender,
+        } as IMatrixMessageProcessorParams;
+        if (profile) {
+            params.displayname = profile.displayname;
+        }
+
         let body: string = "";
         if (event.type !== "m.sticker") {
-            body = await this.matrixMsgProcessor.FormatMessage(event.content as IMatrixMessage, channel.guild, profile);
+            body = await this.matrixMsgProcessor.FormatMessage(event.content as IMatrixMessage, channel.guild, params);
         }
 
         const messageEmbed = new Discord.RichEmbed();

--- a/src/matrixmessageprocessor.ts
+++ b/src/matrixmessageprocessor.ts
@@ -96,7 +96,7 @@ export class MatrixMessageProcessor {
     }
 
     private parseChannel(id: string): string {
-        const CHANNEL_REGEX = /^#_discord_([0-9]*)/;
+        const CHANNEL_REGEX = /^#_discord_[0-9]*_([0-9]*)/;
         const match = id.match(CHANNEL_REGEX);
         if (!match || !this.guild.channels.get(match[1])) {
             return "";

--- a/src/matrixmessageprocessor.ts
+++ b/src/matrixmessageprocessor.ts
@@ -1,11 +1,21 @@
 import * as Discord from "discord.js";
 import { IMatrixMessage } from "./matrixtypes";
+import * as Parser from "node-html-parser";
+import { Util } from "./util";
 
 export class MatrixMessageProcessor {
     public async FormatMessage(msg: IMatrixMessage, guild: Discord.Guild): Promise<string> {
         let reply = "";
         if (msg.formatted_body) {
-            
+            // parser needs everything wrapped in html elements
+            // so we wrap everything in <div> just to be sure stuff is wrapped
+            // as <div> will be un-touched anyways
+            const parsed = Parser.parse(`<div>${msg.formatted_body}</div>`, {
+                lowerCaseTagName: true,
+                pre: true,
+            // tslint:disable-next-line no-any
+            } as any);
+            reply = await this.walkNode(parsed);
         } else {
             reply = this.escapeDiscord(msg.body);
         }
@@ -15,8 +25,66 @@ export class MatrixMessageProcessor {
     private escapeDiscord(msg: string): string {
         const escapeChars = ["\\", "*", "_", "~", "`"];
         escapeChars.forEach((char) => {
-            msg = msg.replace(new RegExp("\\"+char, "g"), "\\" + char);
+            msg = msg.replace(new RegExp("\\" + char, "g"), "\\" + char);
         });
         return msg;
+    }
+
+    private parsePreContent(node: Parser.HTMLElement): string {
+        let text = node.text;
+        const match = text.match(/^<code([^>]*)>/i);
+        if (!match) {
+            if (text[0] !== "\n") {
+                text = "\n" + text;
+            }
+            return text;
+        }
+        // remove <code> opening-tag
+        text = text.substr(match[0].length);
+        // remove </code> closing tag
+        text = text.replace(/<\/code>$/i, "");
+        if (text[0] !== "\n") {
+            text = "\n" + text;
+        }
+        const language = match[1].match(/language-(\w*)/i);
+        if (language) {
+            text = language[1] + text;
+        }
+        return text;
+    }
+
+    private async walkChildNodes(node: Parser.Node): Promise<string> {
+        let reply = "";
+        await Util.AsyncForEach(node.childNodes, async (child) => {
+            reply += await this.walkNode(child);
+        });
+        return reply;
+    }
+
+    private async walkNode(node: Parser.Node): Promise<string> {
+        if (node.nodeType === Parser.NodeType.TEXT_NODE) {
+            return this.escapeDiscord((node as Parser.TextNode).text);
+        } else if (node.nodeType === Parser.NodeType.ELEMENT_NODE) {
+            let _node = node as Parser.HTMLElement;
+            switch (_node.tagName) {
+                case 'em':
+                case 'i':
+                    return `*${await this.walkChildNodes(_node)}*`;
+                case 'strong':
+                case 'b':
+                    return `**${await this.walkChildNodes(_node)}**`;
+                case 'u':
+                    return `__${await this.walkChildNodes(_node)}__`;
+                case 'del':
+                    return `~~${await this.walkChildNodes(_node)}~~`;
+                case 'code':
+                    return `\`${this.escapeDiscord(_node.innerHTML)}\``;
+                case 'pre':
+                    return `\n\`\`\`${this.parsePreContent(_node)}\`\`\`\n`;
+                default:
+                    return await this.walkChildNodes(_node);
+            }
+        }
+        return "";
     }
 }

--- a/src/matrixmessageprocessor.ts
+++ b/src/matrixmessageprocessor.ts
@@ -65,24 +65,24 @@ export class MatrixMessageProcessor {
         if (node.nodeType === Parser.NodeType.TEXT_NODE) {
             return this.escapeDiscord((node as Parser.TextNode).text);
         } else if (node.nodeType === Parser.NodeType.ELEMENT_NODE) {
-            let _node = node as Parser.HTMLElement;
+            const nodeHtml = node as Parser.HTMLElement;
             switch (_node.tagName) {
-                case 'em':
-                case 'i':
-                    return `*${await this.walkChildNodes(_node)}*`;
-                case 'strong':
-                case 'b':
-                    return `**${await this.walkChildNodes(_node)}**`;
-                case 'u':
-                    return `__${await this.walkChildNodes(_node)}__`;
-                case 'del':
-                    return `~~${await this.walkChildNodes(_node)}~~`;
-                case 'code':
-                    return `\`${this.escapeDiscord(_node.innerHTML)}\``;
-                case 'pre':
-                    return `\n\`\`\`${this.parsePreContent(_node)}\`\`\`\n`;
+                case "em":
+                case "i":
+                    return `*${await this.walkChildNodes(nodeHtml)}*`;
+                case "strong":
+                case "b":
+                    return `**${await this.walkChildNodes(nodeHtml)}**`;
+                case "u":
+                    return `__${await this.walkChildNodes(nodeHtml)}__`;
+                case "del":
+                    return `~~${await this.walkChildNodes(nodeHtml)}~~`;
+                case "code":
+                    return `\`${this.escapeDiscord(nodeHtml.innerHTML)}\``;
+                case "pre":
+                    return `\n\`\`\`${this.parsePreContent(nodeHtml)}\`\`\`\n`;
                 default:
-                    return await this.walkChildNodes(_node);
+                    return await this.walkChildNodes(nodeHtml);
             }
         }
         return "";

--- a/src/matrixmessageprocessor.ts
+++ b/src/matrixmessageprocessor.ts
@@ -66,7 +66,7 @@ export class MatrixMessageProcessor {
             return this.escapeDiscord((node as Parser.TextNode).text);
         } else if (node.nodeType === Parser.NodeType.ELEMENT_NODE) {
             const nodeHtml = node as Parser.HTMLElement;
-            switch (_node.tagName) {
+            switch (nodeHtml.tagName) {
                 case "em":
                 case "i":
                     return `*${await this.walkChildNodes(nodeHtml)}*`;
@@ -78,9 +78,9 @@ export class MatrixMessageProcessor {
                 case "del":
                     return `~~${await this.walkChildNodes(nodeHtml)}~~`;
                 case "code":
-                    return `\`${this.escapeDiscord(nodeHtml.innerHTML)}\``;
+                    return `\`${nodeHtml.text}\``;
                 case "pre":
-                    return `\n\`\`\`${this.parsePreContent(nodeHtml)}\`\`\`\n`;
+                    return `\`\`\`${this.parsePreContent(nodeHtml)}\`\`\`\n`;
                 default:
                     return await this.walkChildNodes(nodeHtml);
             }

--- a/src/matrixmessageprocessor.ts
+++ b/src/matrixmessageprocessor.ts
@@ -1,0 +1,22 @@
+import * as Discord from "discord.js";
+import { IMatrixMessage } from "./matrixtypes";
+
+export class MatrixMessageProcessor {
+    public async FormatMessage(msg: IMatrixMessage, guild: Discord.Guild): Promise<string> {
+        let reply = "";
+        if (msg.formatted_body) {
+            
+        } else {
+            reply = this.escapeDiscord(msg.body);
+        }
+        return reply;
+    }
+
+    private escapeDiscord(msg: string): string {
+        const escapeChars = ["\\", "*", "_", "~", "`"];
+        escapeChars.forEach((char) => {
+            msg = msg.replace(new RegExp("\\"+char, "g"), "\\" + char);
+        });
+        return msg;
+    }
+}

--- a/src/matrixmessageprocessor.ts
+++ b/src/matrixmessageprocessor.ts
@@ -183,7 +183,27 @@ export class MatrixMessageProcessor {
             return `${"    ".repeat(this.listDepth)}${bulletPoint} ${s}`;
         }).join("\n");
 
-        // thefuck?
+        if (this.listDepth === 0) {
+            msg = `\n${msg}\n\n`;
+        }
+        return msg;
+    }
+
+    private async parseOlContent(node: Parser.HTMLElement): Promise<string> {
+        this.listDepth++;
+        const entries = await this.arrayChildNodes(node, ["li"]);
+        this.listDepth--;
+        let entry = 0;
+        const attrs = node.attributes;
+        if (attrs.start && attrs.start.match(/^[0-9]+$/)) {
+            entry = parseInt(attrs.start, 10) - 1;
+        }
+
+        let msg = entries.map((s) => {
+            entry++;
+            return `${"    ".repeat(this.listDepth)}${entry}. ${s}`;
+        }).join("\n");
+
         if (this.listDepth === 0) {
             msg = `\n${msg}\n\n`;
         }
@@ -246,6 +266,8 @@ export class MatrixMessageProcessor {
                     return await this.parseBlockquoteContent(nodeHtml);
                 case "ul":
                     return await this.parseUlContent(nodeHtml);
+                case "ol":
+                    return await this.parseOlContent(nodeHtml);
                 default:
                     return await this.walkChildNodes(nodeHtml);
             }

--- a/src/matrixmessageprocessor.ts
+++ b/src/matrixmessageprocessor.ts
@@ -32,6 +32,7 @@ export class MatrixMessageProcessor {
             // tslint:disable-next-line no-any
             } as any);
             reply = await this.walkNode(parsed);
+            reply = reply.replace(/\s*$/, ""); // trim off whitespace at end
         } else {
             reply = this.escapeDiscord(msg.body);
         }
@@ -161,9 +162,11 @@ export class MatrixMessageProcessor {
 
     private async parseBlockquoteContent(node: Parser.HTMLElement): Promise<string> {
         let msg = await this.walkChildNodes(node);
+
         msg = msg.split("\n").map((s) => {
             return "> " + s;
-        }).join("\n") + "\n";
+        }).join("\n");
+        msg = msg + "\n\n";
         return msg;
     }
 
@@ -177,6 +180,10 @@ export class MatrixMessageProcessor {
 
     private async walkNode(node: Parser.Node): Promise<string> {
         if (node.nodeType === Parser.NodeType.TEXT_NODE) {
+            // ignore \n between single nodes
+            if ((node as Parser.TextNode).text === "\n") {
+                return "";
+            }
             return this.escapeDiscord((node as Parser.TextNode).text);
         } else if (node.nodeType === Parser.NodeType.ELEMENT_NODE) {
             const nodeHtml = node as Parser.HTMLElement;

--- a/src/matrixmessageprocessor.ts
+++ b/src/matrixmessageprocessor.ts
@@ -268,6 +268,8 @@ export class MatrixMessageProcessor {
                     return await this.parseUlContent(nodeHtml);
                 case "ol":
                     return await this.parseOlContent(nodeHtml);
+                case "mx-reply":
+                    return "";
                 default:
                     return await this.walkChildNodes(nodeHtml);
             }

--- a/src/matrixmessageprocessor.ts
+++ b/src/matrixmessageprocessor.ts
@@ -8,15 +8,11 @@ const MIN_NAME_LENGTH = 2;
 const MAX_NAME_LENGTH = 32;
 const MATRIX_TO_LINK = "https://matrix.to/#/";
 
-export class MatrixMessageProcessorOpts {
-    constructor(readonly disableEveryone: boolean = true, readonly disableHere: boolean = true) { }
-}
-
 export class MatrixMessageProcessor {
     private guild: Discord.Guild;
     private listDepth: number = 0;
     private listBulletPoints: string[] = ["●", "○", "■", "‣"];
-    constructor(public bot: DiscordBot, public opts: MatrixMessageProcessorOpts) { }
+    constructor(public bot: DiscordBot) { }
     public async FormatMessage(
         msg: IMatrixMessage,
         guild: Discord.Guild,
@@ -54,12 +50,10 @@ export class MatrixMessageProcessor {
     }
 
     private escapeDiscord(msg: string): string {
-        if (this.opts.disableEveryone) {
-            msg = msg.replace(/@everyone/g, "@ everyone");
-        }
-        if (this.opts.disableHere) {
-            msg = msg.replace(/@here/g, "@ here");
-        }
+        // \u200B is the zero-width space --> they still look the same but don't mention
+        msg = msg.replace(/@everyone/g, "@\u200Beveryone");
+        msg = msg.replace(/@here/g, "@\u200Bhere");
+
         msg = msg.replace(/@room/g, "@here");
         const escapeChars = ["\\", "*", "_", "~", "`"];
         escapeChars.forEach((char) => {

--- a/src/matrixmessageprocessor.ts
+++ b/src/matrixmessageprocessor.ts
@@ -56,6 +56,7 @@ export class MatrixMessageProcessor {
         if (this.opts.disableHere) {
             msg = msg.replace(/@here/g, "@ here");
         }
+        msg = msg.replace(/@room/g, "@here");
         const escapeChars = ["\\", "*", "_", "~", "`"];
         escapeChars.forEach((char) => {
             msg = msg.replace(new RegExp("\\" + char, "g"), "\\" + char);

--- a/src/matrixmessageprocessor.ts
+++ b/src/matrixmessageprocessor.ts
@@ -99,7 +99,7 @@ export class MatrixMessageProcessor {
         const CHANNEL_REGEX = /^#_discord_[0-9]*_([0-9]*)/;
         const match = id.match(CHANNEL_REGEX);
         if (!match || !this.guild.channels.get(match[1])) {
-            return "";
+            return MATRIX_TO_LINK + id;
         }
         return `<#${match[1]}>`;
     }

--- a/src/matrixmessageprocessor.ts
+++ b/src/matrixmessageprocessor.ts
@@ -159,6 +159,14 @@ export class MatrixMessageProcessor {
         return `<${emoji.animated ? "a" : ""}:${emoji.name}:${emoji.id}>`;
     }
 
+    private async parseBlockquoteContent(node: Parser.HTMLElement): Promise<string> {
+        let msg = await this.walkChildNodes(node);
+        msg = msg.split("\n").map((s) => {
+            return "> " + s;
+        }).join("\n") + "\n";
+        return msg;
+    }
+
     private async walkChildNodes(node: Parser.Node): Promise<string> {
         let reply = "";
         await Util.AsyncForEach(node.childNodes, async (child) => {
@@ -193,6 +201,8 @@ export class MatrixMessageProcessor {
                     return await this.parseImageContent(nodeHtml);
                 case "br":
                     return "\n";
+                case "blockquote":
+                    return await this.parseBlockquoteContent(nodeHtml);
                 default:
                     return await this.walkChildNodes(nodeHtml);
             }

--- a/src/matrixmessageprocessor.ts
+++ b/src/matrixmessageprocessor.ts
@@ -3,23 +3,33 @@ import { IMatrixMessage, IMatrixEvent } from "./matrixtypes";
 import * as Parser from "node-html-parser";
 import { Util } from "./util";
 import { DiscordBot } from "./bot";
+import { Client as MatrixClient } from "matrix-js-sdk";
 
 const MIN_NAME_LENGTH = 2;
 const MAX_NAME_LENGTH = 32;
 const MATRIX_TO_LINK = "https://matrix.to/#/";
 
+export interface IMatrixMessageProcessorParams {
+    displayname?: string;
+    mxClient?: MatrixClient;
+    roomId?: string;
+    userId?: string;
+}
+
 export class MatrixMessageProcessor {
     private guild: Discord.Guild;
     private listDepth: number = 0;
     private listBulletPoints: string[] = ["●", "○", "■", "‣"];
+    private params?: IMatrixMessageProcessorParams;
     constructor(public bot: DiscordBot) { }
     public async FormatMessage(
         msg: IMatrixMessage,
         guild: Discord.Guild,
-        profile?: IMatrixEvent | null,
+        params?: IMatrixMessageProcessorParams,
     ): Promise<string> {
         this.guild = guild;
         this.listDepth = 0;
+        this.params = params;
         let reply = "";
         if (msg.formatted_body) {
             // parser needs everything wrapped in html elements
@@ -33,15 +43,15 @@ export class MatrixMessageProcessor {
             reply = await this.walkNode(parsed);
             reply = reply.replace(/\s*$/, ""); // trim off whitespace at end
         } else {
-            reply = this.escapeDiscord(msg.body);
+            reply = await this.escapeDiscord(msg.body);
         }
 
         if (msg.msgtype === "m.emote") {
-            if (profile &&
-                profile.displayname &&
-                profile.displayname.length >= MIN_NAME_LENGTH &&
-                profile.displayname.length <= MAX_NAME_LENGTH) {
-                reply = `_${profile.displayname} ${reply}_`;
+            if (params &&
+                params.displayname &&
+                params.displayname.length >= MIN_NAME_LENGTH &&
+                params.displayname.length <= MAX_NAME_LENGTH) {
+                reply = `_${params.displayname} ${reply}_`;
             } else {
                 reply = `_${reply}_`;
             }
@@ -49,12 +59,24 @@ export class MatrixMessageProcessor {
         return reply;
     }
 
-    private escapeDiscord(msg: string): string {
+    private async escapeDiscord(msg: string): Promise<string> {
         // \u200B is the zero-width space --> they still look the same but don't mention
         msg = msg.replace(/@everyone/g, "@\u200Beveryone");
         msg = msg.replace(/@here/g, "@\u200Bhere");
 
-        msg = msg.replace(/@room/g, "@here");
+        if (msg.includes("@room") && this.params && this.params.mxClient && this.params.roomId && this.params.userId) {
+            // let's check for more complex logic if @room should be replaced
+            const res: IMatrixEvent = await this.params.mxClient.getStateEvent(this.params.roomId, "m.room.power_levels");
+            if (
+                res && res.users
+                && res.users[this.params.userId] !== undefined
+                && res.notifications
+                && res.notifications.room !== undefined
+                && res.users[this.params.userId] >= res.notifications.room
+            ) {
+                msg = msg.replace(/@room/g, "@here");
+            }
+        }
         const escapeChars = ["\\", "*", "_", "~", "`"];
         escapeChars.forEach((char) => {
             msg = msg.replace(new RegExp("\\" + char, "g"), "\\" + char);
@@ -152,7 +174,7 @@ export class MatrixMessageProcessor {
         }
 
         if (!emoji) {
-            return this.escapeDiscord(name);
+            return await this.escapeDiscord(name);
         }
         return `<${emoji.animated ? "a" : ""}:${emoji.name}:${emoji.id}>`;
     }
@@ -232,7 +254,7 @@ export class MatrixMessageProcessor {
             if ((node as Parser.TextNode).text === "\n") {
                 return "";
             }
-            return this.escapeDiscord((node as Parser.TextNode).text);
+            return await this.escapeDiscord((node as Parser.TextNode).text);
         } else if (node.nodeType === Parser.NodeType.ELEMENT_NODE) {
             const nodeHtml = node as Parser.HTMLElement;
             switch (nodeHtml.tagName) {

--- a/src/matrixmessageprocessor.ts
+++ b/src/matrixmessageprocessor.ts
@@ -270,6 +270,8 @@ export class MatrixMessageProcessor {
                     return await this.parseOlContent(nodeHtml);
                 case "mx-reply":
                     return "";
+                case "hr":
+                    return "\n----------\n";
                 default:
                     return await this.walkChildNodes(nodeHtml);
             }

--- a/src/matrixtypes.ts
+++ b/src/matrixtypes.ts
@@ -24,3 +24,10 @@ export interface IMatrixEvent {
     unsigned?: any; // tslint:disable-line no-any
     origin_server_ts?: number;
 }
+
+export interface IMatrixMessage {
+    body: string;
+    msgtype: string;
+    formatted_body?: string;
+    format?: string;
+}

--- a/src/matrixtypes.ts
+++ b/src/matrixtypes.ts
@@ -23,6 +23,8 @@ export interface IMatrixEvent {
     content?: IMatrixEventContent;
     unsigned?: any; // tslint:disable-line no-any
     origin_server_ts?: number;
+    users?: any; // tslint:disable-line no-any
+    notifications?: any; // tslint:disable-line no-any
 }
 
 export interface IMatrixMessage {

--- a/src/util.ts
+++ b/src/util.ts
@@ -238,17 +238,6 @@ export class Util {
         return {command, args};
     }
 
-    public static GetReplyFromReplyBody(body: string) {
-        const lines = body.split("\n");
-        while (lines[0].startsWith("> ") || lines[0].trim().length === 0) {
-            lines.splice(0, 1);
-            if (lines.length === 0) {
-                return "";
-            }
-        }
-        return lines.join("\n").trim();
-    }
-
     public static async AsyncForEach(arr, callback) {
         for (let i = 0; i < arr.length; i++) {
             await callback(arr[i], i, arr);

--- a/test/mocks/emoji.ts
+++ b/test/mocks/emoji.ts
@@ -3,5 +3,5 @@
 /* tslint:disable:no-unused-expression max-file-line-count no-any */
 
 export class MockEmoji {
-    constructor(public id: string = "", public name = "") { }
+    constructor(public id: string = "", public name = "", public animated = false) { }
 }

--- a/test/test_channelsyncroniser.ts
+++ b/test/test_channelsyncroniser.ts
@@ -8,7 +8,6 @@ import { MockGuild } from "./mocks/guild";
 import { MockMember } from "./mocks/member";
 import { MatrixEventProcessor, MatrixEventProcessorOpts } from "../src/matrixeventprocessor";
 import { DiscordBridgeConfig } from "../src/config";
-import { MessageProcessor, MessageProcessorOpts } from "../src/messageprocessor";
 import { MockChannel } from "./mocks/channel";
 import { Bridge, MatrixRoom, RemoteRoom } from "matrix-appservice-bridge";
 

--- a/test/test_discordbot.ts
+++ b/test/test_discordbot.ts
@@ -3,7 +3,6 @@ import * as Proxyquire from "proxyquire";
 import * as Discord from "discord.js";
 import { Log } from "../src/log";
 
-import { MessageProcessorMatrixResult } from "../src/messageprocessor";
 import { MockGuild } from "./mocks/guild";
 import { MockMember } from "./mocks/member";
 import { DiscordBot } from "../src/bot";

--- a/test/test_discordmessageprocessor.ts
+++ b/test/test_discordmessageprocessor.ts
@@ -1,6 +1,6 @@
 import * as Chai from "chai";
 import * as Discord from "discord.js";
-import { MessageProcessor, MessageProcessorOpts } from "../src/messageprocessor";
+import { DiscordMessageProcessor, DiscordMessageProcessorOpts } from "../src/discordmessageprocessor";
 import { DiscordBot } from "../src/bot";
 import { MockGuild } from "./mocks/guild";
 import { MockMember } from "./mocks/member";
@@ -20,15 +20,16 @@ const bot = {
     },
 };
 
-describe("MessageProcessor", () => {
+describe("DiscordMessageProcessor", () => {
     describe("init", () => {
         it("constructor", () => {
-            const mp = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const mp = new DiscordMessageProcessor(new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
         });
     });
     describe("FormatDiscordMessage", () => {
         it("processes plain text messages correctly", async () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const msg = new MockMessage() as any;
             msg.embeds = [];
             msg.content = "Hello World!";
@@ -37,7 +38,8 @@ describe("MessageProcessor", () => {
             Chai.assert(result.formattedBody, "Hello World!");
         });
         it("processes markdown messages correctly.", async () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const msg = new MockMessage() as any;
             msg.embeds = [];
             msg.content = "Hello *World*!";
@@ -46,7 +48,8 @@ describe("MessageProcessor", () => {
             Chai.assert.equal(result.formattedBody, "Hello <em>World</em>!");
         });
         it("processes non-discord markdown correctly.", async () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const msg = new MockMessage() as any;
             msg.embeds = [];
             msg.content = "> inb4 tests";
@@ -62,7 +65,8 @@ describe("MessageProcessor", () => {
                 "[test](<a href=\"http://example.com\">http://example.com</a>)");
         });
         it("processes discord-specific markdown correctly.", async () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const msg = new MockMessage() as any;
             msg.embeds = [];
             msg.content = "_ italic _";
@@ -73,7 +77,8 @@ describe("MessageProcessor", () => {
     });
     describe("FormatEmbeds", () => {
         it("should format embeds correctly", async () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const msg = new MockMessage() as any;
             msg.embeds = [
                 {
@@ -103,7 +108,8 @@ describe("MessageProcessor", () => {
                 "</h5>Description");
         });
         it("should ignore same-url embeds", async () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const msg = new MockMessage() as any;
             msg.embeds = [
                 {
@@ -135,7 +141,8 @@ describe("MessageProcessor", () => {
     });
     describe("FormatEdit", () => {
         it("should format basic edits appropriately", async () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const oldMsg = new MockMessage() as any;
             const newMsg = new MockMessage() as any;
             oldMsg.embeds = [];
@@ -151,7 +158,8 @@ describe("MessageProcessor", () => {
         });
 
         it("should format markdown heavy edits apropriately", async () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const oldMsg = new MockMessage() as any;
             const newMsg = new MockMessage() as any;
             oldMsg.embeds = [];
@@ -171,7 +179,8 @@ describe("MessageProcessor", () => {
 
     describe("InsertUser / HTML", () => {
         it("processes members missing from the guild correctly", () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const guild: any = new MockGuild("123", []);
             const channel = new Discord.TextChannel(guild, {});
             const msg = new MockMessage(channel) as any;
@@ -184,7 +193,8 @@ describe("MessageProcessor", () => {
                 "<a href=\"https://matrix.to/#/@_discord_12345:localhost\">@_discord_12345:localhost</a>");
         });
         it("processes members with usernames correctly", () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const guild: any = new MockGuild("123", []);
             guild._mockAddMember(new MockMember("12345", "TestUsername"));
             const channel = new Discord.TextChannel(guild, {});
@@ -198,7 +208,8 @@ describe("MessageProcessor", () => {
                 "<a href=\"https://matrix.to/#/@_discord_12345:localhost\">TestUsername</a>");
         });
         it("processes members with nickname correctly", () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const guild: any = new MockGuild("123", []);
             guild._mockAddMember(new MockMember("12345", "TestUsername", null, "TestNickname"));
             const channel = new Discord.TextChannel(guild, {});
@@ -214,7 +225,8 @@ describe("MessageProcessor", () => {
     });
     describe("InsertChannel / HTML", () => {
         it("processes unknown channel correctly", () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const guild: any = new MockGuild("123", []);
             const channel = new Discord.TextChannel(guild, {id: "456", name: "TestChannel"});
             const msg = new MockMessage(channel) as any;
@@ -227,7 +239,8 @@ describe("MessageProcessor", () => {
                 "<a href=\"https://matrix.to/#/#_discord_123_123456789:localhost\">#123456789</a>");
         });
         it("processes channels correctly", () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const guild: any = new MockGuild("123", []);
             const channel = new Discord.TextChannel(guild, {id: "456", name: "TestChannel"});
             guild.channels.set("456", channel);
@@ -243,7 +256,8 @@ describe("MessageProcessor", () => {
     });
     describe("InsertRole / HTML", () => {
         it("ignores unknown roles", () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const guild: any = new MockGuild("123", []);
             const channel = new Discord.TextChannel(guild, {id: "456", name: "TestChannel"});
             guild.channels.set("456", channel);
@@ -258,7 +272,8 @@ describe("MessageProcessor", () => {
             Chai.assert.equal(reply, "&lt;@&amp;1234&gt;");
         });
         it("parses known roles", () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const guild: any = new MockGuild("123", []);
             const channel = new Discord.TextChannel(guild, {id: "456", name: "TestChannel"});
             guild.channels.set("456", channel);
@@ -276,7 +291,8 @@ describe("MessageProcessor", () => {
     });
     describe("InsertEmoji", () => {
         it("inserts static emojis to their post-parse flag", () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const content = {
                 animated: false,
                 id: "1234",
@@ -286,7 +302,8 @@ describe("MessageProcessor", () => {
             Chai.assert.equal(reply, "\x01blah\x010\x011234\x01");
         });
         it("inserts animated emojis to their post-parse flag", () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const content = {
                 animated: true,
                 id: "1234",
@@ -298,7 +315,8 @@ describe("MessageProcessor", () => {
     });
     describe("InsertMxcImages / HTML", () => {
         it("processes unknown emoji correctly", async () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const guild: any = new MockGuild("123", []);
             const channel = new Discord.TextChannel(guild, {id: "456", name: "TestChannel"});
             const msg = new MockMessage(channel) as any;
@@ -310,7 +328,8 @@ describe("MessageProcessor", () => {
             Chai.assert.equal(reply, "Hello &lt;:hello:123456789&gt;");
         });
         it("processes emoji correctly", async () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const guild: any = new MockGuild("123", []);
             const channel = new Discord.TextChannel(guild, {id: "456", name: "TestChannel"});
             guild.channels.set("456", channel);
@@ -325,7 +344,8 @@ describe("MessageProcessor", () => {
     });
     describe("InsertEmbeds", () => {
         it("processes titleless embeds properly", () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const msg = new MockMessage() as any;
             msg.embeds = [
                 new Discord.MessageEmbed(msg, {
@@ -337,7 +357,8 @@ describe("MessageProcessor", () => {
             Chai.assert.equal(content, "\n\n----\nTestDescription");
         });
         it("processes urlless embeds properly", () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const msg = new MockMessage() as any;
             msg.embeds = [
                 new Discord.MessageEmbed(msg, {
@@ -350,7 +371,8 @@ describe("MessageProcessor", () => {
             Chai.assert.equal(content, "\n\n----\n##### TestTitle\nTestDescription");
         });
         it("processes linked embeds properly", () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const msg = new MockMessage() as any;
             msg.embeds = [
                 new Discord.MessageEmbed(msg, {
@@ -364,7 +386,8 @@ describe("MessageProcessor", () => {
             Chai.assert.equal(content, "\n\n----\n##### [TestTitle](testurl)\nTestDescription");
         });
         it("rejects titleless and descriptionless embeds", () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const msg = new MockMessage() as any;
             msg.embeds = [
                 new Discord.MessageEmbed(msg, {
@@ -376,7 +399,8 @@ describe("MessageProcessor", () => {
             Chai.assert.equal(content, "Some content...");
         });
         it("processes multiple embeds properly", () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const msg = new MockMessage() as any;
             msg.embeds = [
                 new Discord.MessageEmbed(msg, {
@@ -398,7 +422,8 @@ describe("MessageProcessor", () => {
             );
         });
         it("inserts embeds properly", () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const msg = new MockMessage() as any;
             msg.embeds = [
                 new Discord.MessageEmbed(msg, {
@@ -421,7 +446,8 @@ TestDescription`,
     });
     describe("Message Type", () => {
         it("sets non-bot messages as m.text", async () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const msg = new MockMessage() as any;
             msg.embeds = [];
             msg.content = "no bot";
@@ -430,7 +456,8 @@ TestDescription`,
             Chai.assert.equal(result.msgtype, "m.text");
         });
         it("sets bot messages as m.notice", async () => {
-            const processor = new MessageProcessor(new MessageProcessorOpts("localhost"), bot as DiscordBot);
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const msg = new MockMessage() as any;
             msg.embeds = [];
             msg.content = "a bot";

--- a/test/test_discordmessageprocessor.ts
+++ b/test/test_discordmessageprocessor.ts
@@ -26,14 +26,14 @@ describe("DiscordMessageProcessor", () => {
             const mp = new DiscordMessageProcessor(new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
         });
     });
-    describe("FormatDiscordMessage", () => {
+    describe("FormatMessage", () => {
         it("processes plain text messages correctly", async () => {
             const processor = new DiscordMessageProcessor(
                 new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
             const msg = new MockMessage() as any;
             msg.embeds = [];
             msg.content = "Hello World!";
-            const result = await processor.FormatDiscordMessage(msg);
+            const result = await processor.FormatMessage(msg);
             Chai.assert(result.body, "Hello World!");
             Chai.assert(result.formattedBody, "Hello World!");
         });
@@ -43,7 +43,7 @@ describe("DiscordMessageProcessor", () => {
             const msg = new MockMessage() as any;
             msg.embeds = [];
             msg.content = "Hello *World*!";
-            const result = await processor.FormatDiscordMessage(msg);
+            const result = await processor.FormatMessage(msg);
             Chai.assert.equal(result.body, "Hello *World*!");
             Chai.assert.equal(result.formattedBody, "Hello <em>World</em>!");
         });
@@ -53,13 +53,13 @@ describe("DiscordMessageProcessor", () => {
             const msg = new MockMessage() as any;
             msg.embeds = [];
             msg.content = "> inb4 tests";
-            let result = await processor.FormatDiscordMessage(msg);
+            let result = await processor.FormatMessage(msg);
             Chai.assert.equal(result.body, "> inb4 tests");
             Chai.assert.equal(result.formattedBody, "&gt; inb4 tests");
 
             msg.embeds = [];
             msg.content = "[test](http://example.com)";
-            result = await processor.FormatDiscordMessage(msg);
+            result = await processor.FormatMessage(msg);
             Chai.assert.equal(result.body, "[test](http://example.com)");
             Chai.assert.equal(result.formattedBody,
                 "[test](<a href=\"http://example.com\">http://example.com</a>)");
@@ -70,7 +70,7 @@ describe("DiscordMessageProcessor", () => {
             const msg = new MockMessage() as any;
             msg.embeds = [];
             msg.content = "_ italic _";
-            const result = await processor.FormatDiscordMessage(msg);
+            const result = await processor.FormatMessage(msg);
             Chai.assert.equal(result.body, "_ italic _");
             Chai.assert.equal(result.formattedBody, "<em> italic </em>");
         });
@@ -102,7 +102,7 @@ describe("DiscordMessageProcessor", () => {
                 },
             ];
             msg.content = "message";
-            const result = await processor.FormatDiscordMessage(msg);
+            const result = await processor.FormatMessage(msg);
             Chai.assert.equal(result.body, "message\n\n----\n##### [Title](http://example.com)\nDescription");
             Chai.assert.equal(result.formattedBody, "message<hr><h5><a href=\"http://example.com\">Title</a>" +
                 "</h5>Description");
@@ -133,7 +133,7 @@ describe("DiscordMessageProcessor", () => {
                 },
             ];
             msg.content = "message http://example.com";
-            const result = await processor.FormatDiscordMessage(msg);
+            const result = await processor.FormatMessage(msg);
             Chai.assert.equal(result.body, "message http://example.com");
             Chai.assert.equal(result.formattedBody, "message <a href=\"http://example.com\">" +
                 "http://example.com</a>");
@@ -452,7 +452,7 @@ TestDescription`,
             msg.embeds = [];
             msg.content = "no bot";
             msg.author.bot = false;
-            const result = await processor.FormatDiscordMessage(msg);
+            const result = await processor.FormatMessage(msg);
             Chai.assert.equal(result.msgtype, "m.text");
         });
         it("sets bot messages as m.notice", async () => {
@@ -462,7 +462,7 @@ TestDescription`,
             msg.embeds = [];
             msg.content = "a bot";
             msg.author.bot = true;
-            const result = await processor.FormatDiscordMessage(msg);
+            const result = await processor.FormatMessage(msg);
             Chai.assert.equal(result.msgtype, "m.notice");
         });
     });

--- a/test/test_matrixeventprocessor.ts
+++ b/test/test_matrixeventprocessor.ts
@@ -59,11 +59,7 @@ const mxClient = {
     },
 };
 
-function createMatrixEventProcessor(
-    disableMentions: boolean = false,
-    disableEveryone = false,
-    disableHere = false,
-): MatrixEventProcessor {
+function createMatrixEventProcessor(): MatrixEventProcessor {
     const bridge = {
         getBot: () => {
             return {
@@ -134,9 +130,6 @@ function createMatrixEventProcessor(
         },
     };
     const config = new DiscordBridgeConfig();
-    config.bridge.disableDiscordMentions = disableMentions;
-    config.bridge.disableEveryoneMention = disableEveryone;
-    config.bridge.disableHereMention = disableHere;
 
     const Util = Object.assign(require("../src/util").Util, {
         DownloadFile: (name: string) => {
@@ -375,26 +368,26 @@ describe("MatrixEventProcessor", () => {
             Chai.assert.equal(author!.url, "https://matrix.to/#/@test:localhost");
         });
 
-        it("Should remove everyone mentions if configured.", async () => {
-            const processor = createMatrixEventProcessor(false, true);
+        it("Should remove everyone mentions.", async () => {
+            const processor = createMatrixEventProcessor();
             const embeds = await processor.EventToEmbed({
                 content: {
                     body: "@everyone Hello!",
                 },
                 sender: "@test:localhost",
             } as IMatrixEvent, mockChannel as any);
-            Chai.assert.equal(embeds.messageEmbed.description, "@ everyone Hello!");
+            Chai.assert.equal(embeds.messageEmbed.description, "@\u200Beveryone Hello!");
         });
 
-        it("Should remove here mentions if configured.", async () => {
-            const processor = createMatrixEventProcessor(false, false, true);
+        it("Should remove here mentions.", async () => {
+            const processor = createMatrixEventProcessor();
             const embeds = await processor.EventToEmbed({
                 content: {
                     body: "@here Hello!",
                 },
                 sender: "@test:localhost",
             } as IMatrixEvent, mockChannel as any);
-            Chai.assert.equal(embeds.messageEmbed.description, "@ here Hello!");
+            Chai.assert.equal(embeds.messageEmbed.description, "@\u200Bhere Hello!");
         });
 
         it("Should replace /me with * displayname, and italicize message", async () => {

--- a/test/test_matrixeventprocessor.ts
+++ b/test/test_matrixeventprocessor.ts
@@ -10,7 +10,6 @@ import { MockMember } from "./mocks/member";
 import { MockEmoji } from "./mocks/emoji";
 import { MatrixEventProcessor, MatrixEventProcessorOpts } from "../src/matrixeventprocessor";
 import { DiscordBridgeConfig } from "../src/config";
-import { MessageProcessor, MessageProcessorOpts } from "../src/messageprocessor";
 import { MockChannel } from "./mocks/channel";
 import { IMatrixEvent } from "../src/matrixtypes";
 

--- a/test/test_matrixmessageprocessor.ts
+++ b/test/test_matrixmessageprocessor.ts
@@ -102,14 +102,44 @@ describe("MatrixMessageProcessor", () => {
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<p>here</p><pre><code>is\ncode\n</code></pre><p>yay</p>");
             const result = await mp.FormatMessage(msg, guild as any);
-            expect(result).is.equal("here\n```\nis\ncode\n```\nyay");
+            expect(result).is.equal("here```\nis\ncode\n```\nyay");
         });
         it("converts multiline language code", async () => {
             const mp = new MatrixMessageProcessor();
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<p>here</p><pre><code class=\"language-js\">is\ncode\n</code></pre><p>yay</p>");
             const result = await mp.FormatMessage(msg, guild as any);
-            expect(result).is.equal("here\n```js\nis\ncode\n```\nyay");
+            expect(result).is.equal("here```js\nis\ncode\n```\nyay");
+        });
+    });
+    describe("FormatMessage / formatted_body / complex", () => {
+        it("html unescapes stuff inside of code", async () => {
+            const mp = new MatrixMessageProcessor();
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("<code>is &lt;em&gt;italic&lt;/em&gt;?</code>");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("`is <em>italic</em>?`");
+        });
+        it("html unescapes inside of pre", async () => {
+            const mp = new MatrixMessageProcessor();
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("<pre><code>wow &amp;</code></pre>");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("```\nwow &```\n");
+        });
+        it("doesn't parse inside of code", async () => {
+            const mp = new MatrixMessageProcessor();
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("<code>*yay*</code>");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("`*yay*`");
+        });
+        it("doesn't parse inside of pre", async () => {
+            const mp = new MatrixMessageProcessor();
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("<pre><code>*yay*</code></pre>");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("```\n*yay*```\n");
         });
     });
 });

--- a/test/test_matrixmessageprocessor.ts
+++ b/test/test_matrixmessageprocessor.ts
@@ -186,6 +186,13 @@ code
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("*test*\n**ing**");
         });
+        it("drops mx-reply", async () => {
+            const mp = new MatrixMessageProcessor(bot, opts);
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("<mx-reply><blockquote>message</blockquote></mx-reply>test reply");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("test reply");
+        });
     });
     describe("FormatMessage / formatted_body / discord", () => {
         it("Parses user pills", async () => {

--- a/test/test_matrixmessageprocessor.ts
+++ b/test/test_matrixmessageprocessor.ts
@@ -381,4 +381,76 @@ code
             expect(result).is.equal("foxes\n● awesome\n● floofy\n    ○ fur\n    ○ tail\n● cute\n\nyay!");
         });
     });
+    it("parses simple ordered lists", async () => {
+        const mp = new MatrixMessageProcessor(bot, opts);
+        const guild = new MockGuild("1234");
+        const msg = getHtmlMessage(`<p>oookay</p>
+<ol>
+<li>test</li>
+<li>test more</li>
+</ol>
+<p>ok?</p>
+`);
+        const result = await mp.FormatMessage(msg, guild as any);
+        expect(result).is.equal("oookay\n1. test\n2. test more\n\nok?");
+    });
+    it("parses nested ordered lists", async () => {
+        const mp = new MatrixMessageProcessor(bot, opts);
+        const guild = new MockGuild("1234");
+        const msg = getHtmlMessage(`<p>and now</p>
+<ol>
+<li>test</li>
+<li>test more
+<ol>
+<li>and more</li>
+<li>more?</li>
+</ol>
+</li>
+<li>done!</li>
+</ol>
+<p>ok?</p>
+`);
+        const result = await mp.FormatMessage(msg, guild as any);
+        expect(result).is.equal("and now\n1. test\n2. test more\n    1. and more\n    2. more?\n3. done!\n\nok?");
+    });
+    it("parses ordered lists with different start", async () => {
+        const mp = new MatrixMessageProcessor(bot, opts);
+        const guild = new MockGuild("1234");
+        const msg = getHtmlMessage(`<ol start="5">
+<li>test</li>
+<li>test more</li>
+</ol>`);
+        const result = await mp.FormatMessage(msg, guild as any);
+        expect(result).is.equal("\n5. test\n6. test more");
+    });
+    it("parses ul in ol", async () => {
+        const mp = new MatrixMessageProcessor(bot, opts);
+        const guild = new MockGuild("1234");
+        const msg = getHtmlMessage(`<ol>
+<li>test</li>
+<li>test more
+<ul>
+<li>asdf</li>
+<li>jklö</li>
+</ul>
+</li>
+</ol>`);
+        const result = await mp.FormatMessage(msg, guild as any);
+        expect(result).is.equal("\n1. test\n2. test more\n    ○ asdf\n    ○ jklö");
+    });
+    it("parses ol in ul", async () => {
+        const mp = new MatrixMessageProcessor(bot, opts);
+        const guild = new MockGuild("1234");
+        const msg = getHtmlMessage(`<ul>
+<li>test</li>
+<li>test more
+<ol>
+<li>asdf</li>
+<li>jklö</li>
+</ol>
+</li>
+</ul>`);
+        const result = await mp.FormatMessage(msg, guild as any);
+        expect(result).is.equal("\n● test\n● test more\n    1. asdf\n    2. jklö");
+    });
 });

--- a/test/test_matrixmessageprocessor.ts
+++ b/test/test_matrixmessageprocessor.ts
@@ -198,14 +198,21 @@ describe("MatrixMessageProcessor", () => {
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("<#12345>");
         });
-        it("Ignores invalid channel pills", async () => {
+        it("Handles invalid channel pills", async () => {
             const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const channel = new MockChannel("12345", guild, "text", "SomeChannel");
             guild.channels.set("12345", channel as any);
             const msg = getHtmlMessage("<a href=\"https://matrix.to/#/#_discord_1234_789:localhost\">#SomeChannel</a>");
             const result = await mp.FormatMessage(msg, guild as any);
-            expect(result).is.equal("#SomeChannel");
+            expect(result).is.equal("https://matrix.to/#/#_discord_1234_789:localhost");
+        });
+        it("Handles external channel pills", async () => {
+            const mp = new MatrixMessageProcessor(bot, opts);
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("<a href=\"https://matrix.to/#/#matrix:matrix.org\">#SomeChannel</a>");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("https://matrix.to/#/#matrix:matrix.org");
         });
         it("Ignores links without href", async () => {
             const mp = new MatrixMessageProcessor(bot, opts);

--- a/test/test_matrixmessageprocessor.ts
+++ b/test/test_matrixmessageprocessor.ts
@@ -134,7 +134,11 @@ describe("MatrixMessageProcessor", () => {
         it("converts multiline language code", async () => {
             const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
-            const msg = getHtmlMessage("<p>here</p><pre><code class=\"language-js\">is\ncode\n</code></pre><p>yay</p>");
+            const msg = getHtmlMessage(`<p>here</p>
+<pre><code class="language-js">is
+code
+</code></pre>
+<p>yay</p>`);
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("here```js\nis\ncode\n```yay");
         });
@@ -174,6 +178,13 @@ describe("MatrixMessageProcessor", () => {
             const msg = getHtmlMessage("<pre><code>*yay*</code></pre>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("```\n*yay*```");
+        });
+        it("parses new lines", async () => {
+            const mp = new MatrixMessageProcessor(bot, opts);
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("<em>test</em><br><strong>ing</strong>");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("*test*\n**ing**");
         });
     });
     describe("FormatMessage / formatted_body / discord", () => {
@@ -285,16 +296,37 @@ describe("MatrixMessageProcessor", () => {
         it("parses single blockquotes", async () => {
             const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
-            const msg = getHtmlMessage("<blockquote>hey</blockquote>\nthere");
+            const msg = getHtmlMessage("<blockquote>hey</blockquote>there");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("> hey\n\nthere");
         });
         it("parses double blockquotes", async () => {
             const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
-            const msg = getHtmlMessage("<blockquote><blockquote>hey</blockquote>\nyou</blockquote>\nthere");
+            const msg = getHtmlMessage("<blockquote><blockquote>hey</blockquote>you</blockquote>there");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("> > hey\n> \n> you\n\nthere");
+        });
+        it("parses blockquotes with <p>", async () => {
+            const mp = new MatrixMessageProcessor(bot, opts);
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("<blockquote>\n<p>spoky</p>\n</blockquote>\n<p>test</p>\n");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("> spoky\n\ntest");
+        });
+        it("parses double blockquotes with <p>", async () => {
+            const mp = new MatrixMessageProcessor(bot, opts);
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage(`<blockquote>
+<blockquote>
+<p>spoky</p>
+</blockquote>
+<p>testing</p>
+</blockquote>
+<p>test</p>
+`);
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("> > spoky\n> \n> testing\n\ntest");
         });
     });
 });

--- a/test/test_matrixmessageprocessor.ts
+++ b/test/test_matrixmessageprocessor.ts
@@ -122,14 +122,21 @@ describe("MatrixMessageProcessor", () => {
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<p>here</p><pre><code>is\ncode\n</code></pre><p>yay</p>");
             const result = await mp.FormatMessage(msg, guild as any);
-            expect(result).is.equal("here```\nis\ncode\n```\nyay");
+            expect(result).is.equal("here```\nis\ncode\n```yay");
         });
         it("converts multiline language code", async () => {
             const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<p>here</p><pre><code class=\"language-js\">is\ncode\n</code></pre><p>yay</p>");
             const result = await mp.FormatMessage(msg, guild as any);
-            expect(result).is.equal("here```js\nis\ncode\n```\nyay");
+            expect(result).is.equal("here```js\nis\ncode\n```yay");
+        });
+        it("handles linebreaks", async () => {
+            const mp = new MatrixMessageProcessor(bot, opts);
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("line<br>break");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("line\nbreak");
         });
     });
     describe("FormatMessage / formatted_body / complex", () => {
@@ -145,7 +152,7 @@ describe("MatrixMessageProcessor", () => {
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<pre><code>wow &amp;</code></pre>");
             const result = await mp.FormatMessage(msg, guild as any);
-            expect(result).is.equal("```\nwow &```\n");
+            expect(result).is.equal("```\nwow &```");
         });
         it("doesn't parse inside of code", async () => {
             const mp = new MatrixMessageProcessor(bot, opts);
@@ -159,7 +166,7 @@ describe("MatrixMessageProcessor", () => {
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<pre><code>*yay*</code></pre>");
             const result = await mp.FormatMessage(msg, guild as any);
-            expect(result).is.equal("```\n*yay*```\n");
+            expect(result).is.equal("```\n*yay*```");
         });
     });
     describe("FormatMessage / formatted_body / discord", () => {

--- a/test/test_matrixmessageprocessor.ts
+++ b/test/test_matrixmessageprocessor.ts
@@ -3,12 +3,30 @@ import * as Discord from "discord.js";
 import { MockGuild } from "./mocks/guild";
 import { MockMember } from "./mocks/member";
 import { MockChannel } from "./mocks/channel";
-import { MatrixMessageProcessor } from "../src/matrixmessageprocessor";
+import { MockEmoji } from "./mocks/emoji";
+import { DiscordBot } from "../src/bot";
+import { DbEmoji } from "../src/db/dbdataemoji";
+import { MatrixMessageProcessor, MatrixMessageProcessorOpts } from "../src/matrixmessageprocessor";
 
 // we are a test file and thus need those
 /* tslint:disable:no-unused-expression max-file-line-count no-any */
 
 const expect = Chai.expect;
+
+const opts = new MatrixMessageProcessorOpts;
+const bot = {
+    GetEmojiByMxc: async (mxc: string): Promise<DbEmoji> => {
+        if (mxc === "mxc://real_emote:localhost") {
+            const emoji = new DbEmoji;
+            emoji.Name = "real_emote";
+            emoji.EmojiId = "123456";
+            emoji.Animated = false;
+            emoji.MxcUrl = mxc;
+            return emoji;
+        }
+        throw new Error("Couldn't fetch from store");
+    },
+} as DiscordBot;
 
 function getPlainMessage(msg: string, msgtype: string = "m.text") {
     return {
@@ -28,21 +46,21 @@ function getHtmlMessage(msg: string, msgtype: string = "m.text") {
 describe("MatrixMessageProcessor", () => {
     describe("FormatMessage / body / simple", () => {
         it("leaves blank stuff untouched", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getPlainMessage("hello world!");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("hello world!");
         });
         it("escapes simple stuff", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getPlainMessage("hello *world* how __are__ you?");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("hello \\*world\\* how \\_\\_are\\_\\_ you?");
         });
         it("escapes more complex stuff", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getPlainMessage("wow \\*this\\* is cool");
             const result = await mp.FormatMessage(msg, guild as any);
@@ -51,63 +69,63 @@ describe("MatrixMessageProcessor", () => {
     });
     describe("FormatMessage / formatted_body / simple", () => {
         it("leaves blank stuff untouched", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("hello world!");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("hello world!");
         });
         it("un-escapes simple stuff", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("foxes &amp; foxes");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("foxes & foxes");
         });
         it("converts italic formatting", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("this text is <em>italic</em> and so is <i>this one</i>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("this text is *italic* and so is *this one*");
         });
         it("converts bold formatting", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("wow some <b>bold</b> and <strong>more</strong> boldness!");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("wow some **bold** and **more** boldness!");
         });
         it("converts underline formatting", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("to be <u>underlined</u> or not to be?");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("to be __underlined__ or not to be?");
         });
         it("converts strike formatting", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("does <del>this text</del> exist?");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("does ~~this text~~ exist?");
         });
         it("converts code", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("WOW this is <code>some awesome</code> code");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("WOW this is `some awesome` code");
         });
         it("converts multiline-code", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<p>here</p><pre><code>is\ncode\n</code></pre><p>yay</p>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("here```\nis\ncode\n```\nyay");
         });
         it("converts multiline language code", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<p>here</p><pre><code class=\"language-js\">is\ncode\n</code></pre><p>yay</p>");
             const result = await mp.FormatMessage(msg, guild as any);
@@ -116,28 +134,28 @@ describe("MatrixMessageProcessor", () => {
     });
     describe("FormatMessage / formatted_body / complex", () => {
         it("html unescapes stuff inside of code", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<code>is &lt;em&gt;italic&lt;/em&gt;?</code>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("`is <em>italic</em>?`");
         });
         it("html unescapes inside of pre", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<pre><code>wow &amp;</code></pre>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("```\nwow &```\n");
         });
         it("doesn't parse inside of code", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<code>*yay*</code>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("`*yay*`");
         });
         it("doesn't parse inside of pre", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<pre><code>*yay*</code></pre>");
             const result = await mp.FormatMessage(msg, guild as any);
@@ -146,7 +164,7 @@ describe("MatrixMessageProcessor", () => {
     });
     describe("FormatMessage / formatted_body / discord", () => {
         it("Parses user pills", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const member = new MockMember("12345", "TestUsername", guild);
             guild.members.set("12345", member);
@@ -155,7 +173,7 @@ describe("MatrixMessageProcessor", () => {
             expect(result).is.equal("<@12345>");
         });
         it("Ignores invalid user pills", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const member = new MockMember("12345", "TestUsername", guild);
             guild.members.set("12345", member);
@@ -164,7 +182,7 @@ describe("MatrixMessageProcessor", () => {
             expect(result).is.equal("TestUsername");
         });
         it("Parses channel pills", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const channel = new MockChannel("12345", guild, "text", "SomeChannel");
             guild.channels.set("12345", channel as any);
@@ -173,7 +191,7 @@ describe("MatrixMessageProcessor", () => {
             expect(result).is.equal("<#12345>");
         });
         it("Ignores invalid channel pills", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const channel = new MockChannel("12345", guild, "text", "SomeChannel");
             guild.channels.set("12345", channel as any);
@@ -182,18 +200,56 @@ describe("MatrixMessageProcessor", () => {
             expect(result).is.equal("#SomeChannel");
         });
         it("Ignores links without href", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<a><em>yay?</em></a>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("*yay?*");
         });
         it("Ignores links with non-matrix href", async () => {
-            const mp = new MatrixMessageProcessor();
+            const mp = new MatrixMessageProcessor(bot, opts);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<a href=\"http://example.com\"><em>yay?</em></a>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("*yay?*");
+        });
+    });
+    describe("FormatMessage / formatted_body / emoji", () => {
+        it("Inserts emoji by name", async () => {
+            const mp = new MatrixMessageProcessor(bot, opts);
+            const guild = new MockGuild("1234");
+            const emoji = new MockEmoji("123456", "test_emoji");
+            guild.emojis.set("123456", emoji);
+            const msg = getHtmlMessage("<img alt=\"test_emoji\">");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("<:test_emoji:123456>");
+        });
+        it("Inserts emojis by mxc url", async () => {
+            const mp = new MatrixMessageProcessor(bot, opts);
+            const guild = new MockGuild("1234");
+            const emoji = new MockEmoji("123456", "test_emoji");
+            guild.emojis.set("123456", emoji);
+            const msg = getHtmlMessage("<img src=\"mxc://real_emote:localhost\">");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("<:test_emoji:123456>");
+        });
+        it("ignores unknown mxc urls", async () => {
+            const mp = new MatrixMessageProcessor(bot, opts);
+            const guild = new MockGuild("1234");
+            const emoji = new MockEmoji("123456", "test_emoji");
+            guild.emojis.set("123456", emoji);
+            const msg = getHtmlMessage("<img alt=\"yay\" src=\"mxc://unreal_emote:localhost\">");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("yay");
+        });
+        it("ignores with no alt / title, too", async () => {
+            const mp = new MatrixMessageProcessor(bot, opts);
+            const guild = new MockGuild("1234");
+            const emoji = new MockEmoji("123456", "test_emoji");
+            guild.emojis.set("123456", emoji);
+            const msg = getHtmlMessage("<img>");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("");
         });
     });
 });

--- a/test/test_matrixmessageprocessor.ts
+++ b/test/test_matrixmessageprocessor.ts
@@ -149,6 +149,13 @@ code
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("line\nbreak");
         });
+        it("handles <hr>", async () => {
+            const mp = new MatrixMessageProcessor(bot, opts);
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("test<hr>foxes");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("test\n----------\nfoxes");
+        });
     });
     describe("FormatMessage / formatted_body / complex", () => {
         it("html unescapes stuff inside of code", async () => {

--- a/test/test_matrixmessageprocessor.ts
+++ b/test/test_matrixmessageprocessor.ts
@@ -281,4 +281,20 @@ describe("MatrixMessageProcessor", () => {
             expect(result).is.equal("");
         });
     });
+    describe("FormatMessage / formatted_body / blockquotes", () => {
+        it("parses single blockquotes", async () => {
+            const mp = new MatrixMessageProcessor(bot, opts);
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("<blockquote>hey</blockquote>\nthere");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("> hey\n\nthere");
+        });
+        it("parses double blockquotes", async () => {
+            const mp = new MatrixMessageProcessor(bot, opts);
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("<blockquote><blockquote>hey</blockquote>\nyou</blockquote>\nthere");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("> > hey\n> \n> you\n\nthere");
+        });
+    });
 });

--- a/test/test_matrixmessageprocessor.ts
+++ b/test/test_matrixmessageprocessor.ts
@@ -66,6 +66,13 @@ describe("MatrixMessageProcessor", () => {
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("wow \\\\\\*this\\\\\\* is cool");
         });
+        it("Converts @room to @here", async () => {
+            const mp = new MatrixMessageProcessor(bot, opts);
+            const guild = new MockGuild("1234");
+            const msg = getPlainMessage("hey @room");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("hey @here");
+        });
     });
     describe("FormatMessage / formatted_body / simple", () => {
         it("leaves blank stuff untouched", async () => {
@@ -227,6 +234,13 @@ describe("MatrixMessageProcessor", () => {
             const msg = getHtmlMessage("<a href=\"http://example.com\"><em>yay?</em></a>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("*yay?*");
+        });
+        it("Converts @room to @here", async () => {
+            const mp = new MatrixMessageProcessor(bot, opts);
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("hey @room");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("hey @here");
         });
     });
     describe("FormatMessage / formatted_body / emoji", () => {

--- a/test/test_matrixmessageprocessor.ts
+++ b/test/test_matrixmessageprocessor.ts
@@ -193,7 +193,8 @@ describe("MatrixMessageProcessor", () => {
             const guild = new MockGuild("1234");
             const channel = new MockChannel("12345", guild, "text", "SomeChannel");
             guild.channels.set("12345", channel as any);
-            const msg = getHtmlMessage("<a href=\"https://matrix.to/#/#_discord_12345:localhost\">#SomeChannel</a>");
+            const msg = getHtmlMessage("<a href=\"https://matrix.to/#/#_discord_1234_12345:" +
+                "localhost\">#SomeChannel</a>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("<#12345>");
         });
@@ -202,7 +203,7 @@ describe("MatrixMessageProcessor", () => {
             const guild = new MockGuild("1234");
             const channel = new MockChannel("12345", guild, "text", "SomeChannel");
             guild.channels.set("12345", channel as any);
-            const msg = getHtmlMessage("<a href=\"https://matrix.to/#/#_discord_789:localhost\">#SomeChannel</a>");
+            const msg = getHtmlMessage("<a href=\"https://matrix.to/#/#_discord_1234_789:localhost\">#SomeChannel</a>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("#SomeChannel");
         });

--- a/test/test_matrixmessageprocessor.ts
+++ b/test/test_matrixmessageprocessor.ts
@@ -13,11 +13,11 @@ import { MatrixMessageProcessor, MatrixMessageProcessorOpts } from "../src/matri
 
 const expect = Chai.expect;
 
-const opts = new MatrixMessageProcessorOpts;
+const opts = new MatrixMessageProcessorOpts();
 const bot = {
     GetEmojiByMxc: async (mxc: string): Promise<DbEmoji> => {
         if (mxc === "mxc://real_emote:localhost") {
-            const emoji = new DbEmoji;
+            const emoji = new DbEmoji();
             emoji.Name = "real_emote";
             emoji.EmojiId = "123456";
             emoji.Animated = false;

--- a/test/test_matrixmessageprocessor.ts
+++ b/test/test_matrixmessageprocessor.ts
@@ -1,0 +1,115 @@
+import * as Chai from "chai";
+import * as Discord from "discord.js";
+import { MockGuild } from "./mocks/guild";
+import { MatrixMessageProcessor } from "../src/matrixmessageprocessor";
+
+// we are a test file and thus need those
+/* tslint:disable:no-unused-expression max-file-line-count no-any */
+
+const expect = Chai.expect;
+
+function getPlainMessage(msg: string, msgtype: string = "m.text") {
+    return {
+        body: msg,
+        msgtype,
+    };
+}
+
+function getHtmlMessage(msg: string, msgtype: string = "m.text") {
+    return {
+        body: msg,
+        formatted_body: msg,
+        msgtype,
+    };
+}
+
+describe("MatrixMessageProcessor", () => {
+    describe("FormatMessage / body / simple", () => {
+        it("leaves blank stuff untouched", async () => {
+            const mp = new MatrixMessageProcessor();
+            const guild = new MockGuild("1234");
+            const msg = getPlainMessage("hello world!");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("hello world!");
+        });
+        it("escapes simple stuff", async () => {
+            const mp = new MatrixMessageProcessor();
+            const guild = new MockGuild("1234");
+            const msg = getPlainMessage("hello *world* how __are__ you?");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("hello \\*world\\* how \\_\\_are\\_\\_ you?");
+        });
+        it("escapes more complex stuff", async () => {
+            const mp = new MatrixMessageProcessor();
+            const guild = new MockGuild("1234");
+            const msg = getPlainMessage("wow \\*this\\* is cool");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("wow \\\\\\*this\\\\\\* is cool");
+        });
+    });
+    describe("FormatMessage / formatted_body / simple", () => {
+        it("leaves blank stuff untouched", async () => {
+            const mp = new MatrixMessageProcessor();
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("hello world!");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("hello world!");
+        });
+        it("un-escapes simple stuff", async () => {
+            const mp = new MatrixMessageProcessor();
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("foxes &amp; foxes");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("foxes & foxes");
+        });
+        it("converts italic formatting", async () => {
+            const mp = new MatrixMessageProcessor();
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("this text is <em>italic</em> and so is <i>this one</i>");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("this text is *italic* and so is *this one*");
+        });
+        it("converts bold formatting", async () => {
+            const mp = new MatrixMessageProcessor();
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("wow some <b>bold</b> and <strong>more</strong> boldness!");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("wow some **bold** and **more** boldness!");
+        });
+        it("converts underline formatting", async () => {
+            const mp = new MatrixMessageProcessor();
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("to be <u>underlined</u> or not to be?");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("to be __underlined__ or not to be?");
+        });
+        it("converts strike formatting", async () => {
+            const mp = new MatrixMessageProcessor();
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("does <del>this text</del> exist?");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("does ~~this text~~ exist?");
+        });
+        it("converts code", async () => {
+            const mp = new MatrixMessageProcessor();
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("WOW this is <code>some awesome</code> code");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("WOW this is `some awesome` code");
+        });
+        it("converts multiline-code", async () => {
+            const mp = new MatrixMessageProcessor();
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("<p>here</p><pre><code>is\ncode\n</code></pre><p>yay</p>");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("here\n```\nis\ncode\n```\nyay");
+        });
+        it("converts multiline language code", async () => {
+            const mp = new MatrixMessageProcessor();
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage("<p>here</p><pre><code class=\"language-js\">is\ncode\n</code></pre><p>yay</p>");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("here\n```js\nis\ncode\n```\nyay");
+        });
+    });
+});

--- a/test/test_matrixmessageprocessor.ts
+++ b/test/test_matrixmessageprocessor.ts
@@ -329,4 +329,56 @@ code
             expect(result).is.equal("> > spoky\n> \n> testing\n\ntest");
         });
     });
+    describe("FormatMessage / formatted_body / lists", () => {
+        it("parses simple unordered lists", async () => {
+            const mp = new MatrixMessageProcessor(bot, opts);
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage(`<p>soru</p>
+<ul>
+<li>test</li>
+<li>ing</li>
+</ul>
+<p>more</p>
+`);
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("soru\n● test\n● ing\n\nmore");
+        });
+        it("parses nested unordered lists", async () => {
+            const mp = new MatrixMessageProcessor(bot, opts);
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage(`<p>foxes</p>
+<ul>
+<li>awesome</li>
+<li>floofy
+<ul>
+<li>fur</li>
+<li>tail</li>
+</ul>
+</li>
+</ul>
+<p>yay!</p>
+`);
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("foxes\n● awesome\n● floofy\n    ○ fur\n    ○ tail\n\nyay!");
+        });
+        it("parses more nested unordered lists", async () => {
+            const mp = new MatrixMessageProcessor(bot, opts);
+            const guild = new MockGuild("1234");
+            const msg = getHtmlMessage(`<p>foxes</p>
+<ul>
+<li>awesome</li>
+<li>floofy
+<ul>
+<li>fur</li>
+<li>tail</li>
+</ul>
+</li>
+<li>cute</li>
+</ul>
+<p>yay!</p>
+`);
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("foxes\n● awesome\n● floofy\n    ○ fur\n    ○ tail\n● cute\n\nyay!");
+        });
+    });
 });

--- a/test/test_matrixmessageprocessor.ts
+++ b/test/test_matrixmessageprocessor.ts
@@ -6,14 +6,13 @@ import { MockChannel } from "./mocks/channel";
 import { MockEmoji } from "./mocks/emoji";
 import { DiscordBot } from "../src/bot";
 import { DbEmoji } from "../src/db/dbdataemoji";
-import { MatrixMessageProcessor, MatrixMessageProcessorOpts } from "../src/matrixmessageprocessor";
+import { MatrixMessageProcessor } from "../src/matrixmessageprocessor";
 
 // we are a test file and thus need those
 /* tslint:disable:no-unused-expression max-file-line-count no-any */
 
 const expect = Chai.expect;
 
-const opts = new MatrixMessageProcessorOpts();
 const bot = {
     GetEmojiByMxc: async (mxc: string): Promise<DbEmoji> => {
         if (mxc === "mxc://real_emote:localhost") {
@@ -46,28 +45,28 @@ function getHtmlMessage(msg: string, msgtype: string = "m.text") {
 describe("MatrixMessageProcessor", () => {
     describe("FormatMessage / body / simple", () => {
         it("leaves blank stuff untouched", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getPlainMessage("hello world!");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("hello world!");
         });
         it("escapes simple stuff", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getPlainMessage("hello *world* how __are__ you?");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("hello \\*world\\* how \\_\\_are\\_\\_ you?");
         });
         it("escapes more complex stuff", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getPlainMessage("wow \\*this\\* is cool");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("wow \\\\\\*this\\\\\\* is cool");
         });
         it("Converts @room to @here", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getPlainMessage("hey @room");
             const result = await mp.FormatMessage(msg, guild as any);
@@ -76,63 +75,63 @@ describe("MatrixMessageProcessor", () => {
     });
     describe("FormatMessage / formatted_body / simple", () => {
         it("leaves blank stuff untouched", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("hello world!");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("hello world!");
         });
         it("un-escapes simple stuff", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("foxes &amp; foxes");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("foxes & foxes");
         });
         it("converts italic formatting", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("this text is <em>italic</em> and so is <i>this one</i>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("this text is *italic* and so is *this one*");
         });
         it("converts bold formatting", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("wow some <b>bold</b> and <strong>more</strong> boldness!");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("wow some **bold** and **more** boldness!");
         });
         it("converts underline formatting", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("to be <u>underlined</u> or not to be?");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("to be __underlined__ or not to be?");
         });
         it("converts strike formatting", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("does <del>this text</del> exist?");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("does ~~this text~~ exist?");
         });
         it("converts code", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("WOW this is <code>some awesome</code> code");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("WOW this is `some awesome` code");
         });
         it("converts multiline-code", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<p>here</p><pre><code>is\ncode\n</code></pre><p>yay</p>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("here```\nis\ncode\n```yay");
         });
         it("converts multiline language code", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage(`<p>here</p>
 <pre><code class="language-js">is
@@ -143,14 +142,14 @@ code
             expect(result).is.equal("here```js\nis\ncode\n```yay");
         });
         it("handles linebreaks", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("line<br>break");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("line\nbreak");
         });
         it("handles <hr>", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("test<hr>foxes");
             const result = await mp.FormatMessage(msg, guild as any);
@@ -159,42 +158,42 @@ code
     });
     describe("FormatMessage / formatted_body / complex", () => {
         it("html unescapes stuff inside of code", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<code>is &lt;em&gt;italic&lt;/em&gt;?</code>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("`is <em>italic</em>?`");
         });
         it("html unescapes inside of pre", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<pre><code>wow &amp;</code></pre>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("```\nwow &```");
         });
         it("doesn't parse inside of code", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<code>*yay*</code>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("`*yay*`");
         });
         it("doesn't parse inside of pre", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<pre><code>*yay*</code></pre>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("```\n*yay*```");
         });
         it("parses new lines", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<em>test</em><br><strong>ing</strong>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("*test*\n**ing**");
         });
         it("drops mx-reply", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<mx-reply><blockquote>message</blockquote></mx-reply>test reply");
             const result = await mp.FormatMessage(msg, guild as any);
@@ -203,7 +202,7 @@ code
     });
     describe("FormatMessage / formatted_body / discord", () => {
         it("Parses user pills", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const member = new MockMember("12345", "TestUsername", guild);
             guild.members.set("12345", member);
@@ -212,7 +211,7 @@ code
             expect(result).is.equal("<@12345>");
         });
         it("Ignores invalid user pills", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const member = new MockMember("12345", "TestUsername", guild);
             guild.members.set("12345", member);
@@ -221,7 +220,7 @@ code
             expect(result).is.equal("TestUsername");
         });
         it("Parses channel pills", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const channel = new MockChannel("12345", guild, "text", "SomeChannel");
             guild.channels.set("12345", channel as any);
@@ -231,7 +230,7 @@ code
             expect(result).is.equal("<#12345>");
         });
         it("Handles invalid channel pills", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const channel = new MockChannel("12345", guild, "text", "SomeChannel");
             guild.channels.set("12345", channel as any);
@@ -240,28 +239,28 @@ code
             expect(result).is.equal("https://matrix.to/#/#_discord_1234_789:localhost");
         });
         it("Handles external channel pills", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<a href=\"https://matrix.to/#/#matrix:matrix.org\">#SomeChannel</a>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("https://matrix.to/#/#matrix:matrix.org");
         });
         it("Ignores links without href", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<a><em>yay?</em></a>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("*yay?*");
         });
         it("Ignores links with non-matrix href", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<a href=\"http://example.com\"><em>yay?</em></a>");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("*yay?*");
         });
         it("Converts @room to @here", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("hey @room");
             const result = await mp.FormatMessage(msg, guild as any);
@@ -270,7 +269,7 @@ code
     });
     describe("FormatMessage / formatted_body / emoji", () => {
         it("Inserts emoji by name", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const emoji = new MockEmoji("123456", "test_emoji");
             guild.emojis.set("123456", emoji);
@@ -279,7 +278,7 @@ code
             expect(result).is.equal("<:test_emoji:123456>");
         });
         it("Inserts emojis by mxc url", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const emoji = new MockEmoji("123456", "test_emoji");
             guild.emojis.set("123456", emoji);
@@ -288,7 +287,7 @@ code
             expect(result).is.equal("<:test_emoji:123456>");
         });
         it("ignores unknown mxc urls", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const emoji = new MockEmoji("123456", "test_emoji");
             guild.emojis.set("123456", emoji);
@@ -297,7 +296,7 @@ code
             expect(result).is.equal("yay");
         });
         it("ignores with no alt / title, too", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const emoji = new MockEmoji("123456", "test_emoji");
             guild.emojis.set("123456", emoji);
@@ -308,28 +307,28 @@ code
     });
     describe("FormatMessage / formatted_body / blockquotes", () => {
         it("parses single blockquotes", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<blockquote>hey</blockquote>there");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("> hey\n\nthere");
         });
         it("parses double blockquotes", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<blockquote><blockquote>hey</blockquote>you</blockquote>there");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("> > hey\n> \n> you\n\nthere");
         });
         it("parses blockquotes with <p>", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage("<blockquote>\n<p>spoky</p>\n</blockquote>\n<p>test</p>\n");
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("> spoky\n\ntest");
         });
         it("parses double blockquotes with <p>", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage(`<blockquote>
 <blockquote>
@@ -345,7 +344,7 @@ code
     });
     describe("FormatMessage / formatted_body / lists", () => {
         it("parses simple unordered lists", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage(`<p>soru</p>
 <ul>
@@ -358,7 +357,7 @@ code
             expect(result).is.equal("soru\n● test\n● ing\n\nmore");
         });
         it("parses nested unordered lists", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage(`<p>foxes</p>
 <ul>
@@ -376,7 +375,7 @@ code
             expect(result).is.equal("foxes\n● awesome\n● floofy\n    ○ fur\n    ○ tail\n\nyay!");
         });
         it("parses more nested unordered lists", async () => {
-            const mp = new MatrixMessageProcessor(bot, opts);
+            const mp = new MatrixMessageProcessor(bot);
             const guild = new MockGuild("1234");
             const msg = getHtmlMessage(`<p>foxes</p>
 <ul>
@@ -396,7 +395,7 @@ code
         });
     });
     it("parses simple ordered lists", async () => {
-        const mp = new MatrixMessageProcessor(bot, opts);
+        const mp = new MatrixMessageProcessor(bot);
         const guild = new MockGuild("1234");
         const msg = getHtmlMessage(`<p>oookay</p>
 <ol>
@@ -409,7 +408,7 @@ code
         expect(result).is.equal("oookay\n1. test\n2. test more\n\nok?");
     });
     it("parses nested ordered lists", async () => {
-        const mp = new MatrixMessageProcessor(bot, opts);
+        const mp = new MatrixMessageProcessor(bot);
         const guild = new MockGuild("1234");
         const msg = getHtmlMessage(`<p>and now</p>
 <ol>
@@ -428,7 +427,7 @@ code
         expect(result).is.equal("and now\n1. test\n2. test more\n    1. and more\n    2. more?\n3. done!\n\nok?");
     });
     it("parses ordered lists with different start", async () => {
-        const mp = new MatrixMessageProcessor(bot, opts);
+        const mp = new MatrixMessageProcessor(bot);
         const guild = new MockGuild("1234");
         const msg = getHtmlMessage(`<ol start="5">
 <li>test</li>
@@ -438,7 +437,7 @@ code
         expect(result).is.equal("\n5. test\n6. test more");
     });
     it("parses ul in ol", async () => {
-        const mp = new MatrixMessageProcessor(bot, opts);
+        const mp = new MatrixMessageProcessor(bot);
         const guild = new MockGuild("1234");
         const msg = getHtmlMessage(`<ol>
 <li>test</li>
@@ -453,7 +452,7 @@ code
         expect(result).is.equal("\n1. test\n2. test more\n    ○ asdf\n    ○ jklö");
     });
     it("parses ol in ul", async () => {
-        const mp = new MatrixMessageProcessor(bot, opts);
+        const mp = new MatrixMessageProcessor(bot);
         const guild = new MockGuild("1234");
         const msg = getHtmlMessage(`<ul>
 <li>test</li>

--- a/test/test_util.ts
+++ b/test/test_util.ts
@@ -125,30 +125,6 @@ describe("Util", () => {
             }
         });
     });
-    describe("GetReplyFromReplyBody", () => {
-        it("Should get a reply from the body", () => {
-            const reply = Util.GetReplyFromReplyBody(`> <@alice:example.org> This is the original body
-
-This is where the reply goes`);
-            expect(reply).to.equal("This is where the reply goes");
-        });
-        it("Should get a multi-line reply from the body", () => {
-            const reply = Util.GetReplyFromReplyBody(`> <@alice:example.org> This is the original body
-
-This is where the reply goes and
-there are even more lines here.`);
-            expect(reply).to.equal("This is where the reply goes and\nthere are even more lines here.");
-        });
-        it("Should get empty string from an empty reply", () => {
-            const reply = Util.GetReplyFromReplyBody(`> <@alice:example.org> This is the original body
-`);
-            expect(reply).to.equal("");
-        });
-        it("Should return body if no reply found", () => {
-            const reply = Util.GetReplyFromReplyBody("Test\nwith\nhalfy");
-            expect(reply).to.equal("Test\nwith\nhalfy");
-        });
-    });
     describe("NumberToHTMLColor", () => {
         it("Should handle valid colors", () => {
             const COLOR = 0xdeadaf;


### PR DESCRIPTION
This checks permissions for @room when sending M -> D and only converts to @here if they are present.

This also removes the options for @everyone and @here escaping as they don't make sense anymore, they are always escaped, using `\u200B` to look nicer on the discord side.

This PR depends on #316 being merged. Changes start at 7e93615 