### PR TITLE
Improve edits on matrix side

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -53,6 +53,7 @@ export class DiscordBot {
     private bridge: Bridge;
     private presenceInterval: number;
     private sentMessages: string[];
+    private lastEventIds: { [channelId: string]: string };
     private discordMsgProcessor: DiscordMessageProcessor;
     private mxEventProcessor: MatrixEventProcessor;
     private presenceHandler: PresenceHandler;
@@ -73,6 +74,7 @@ export class DiscordBot {
         );
         this.presenceHandler = new PresenceHandler(this);
         this.discordMessageQueue = {};
+        this.lastEventIds = {};
     }
 
     public setBridge(bridge: Bridge) {
@@ -314,6 +316,7 @@ export class DiscordBot {
         await Util.AsyncForEach(res, async (m: Discord.Message) => {
             log.verbose("Sent (state msg) ", m.id);
             this.sentMessages.push(m.id);
+            this.lastEventIds[event.room_id] = event.event_id;
             const evt = new DbEvent();
             evt.MatrixId = `${event.event_id};${event.room_id}`;
             evt.DiscordId = m.id;
@@ -385,6 +388,7 @@ export class DiscordBot {
         await Util.AsyncForEach(msg, async (m: Discord.Message) => {
             log.verbose("Sent ", m.id);
             this.sentMessages.push(m.id);
+            this.lastEventIds[event.room_id] = event.event_id;
             const evt = new DbEvent();
             evt.MatrixId = `${event.event_id};${event.room_id}`;
             evt.DiscordId = m.id;
@@ -534,6 +538,7 @@ export class DiscordBot {
                 formatted_body: matrixMsg.formattedBody,
                 msgtype: "m.text",
             });
+            this.lastEventIds[room] = res.event_id;
             const evt = new DbEvent();
             evt.MatrixId = `${res.event_id};${room}`;
             evt.DiscordId = msgID;
@@ -648,6 +653,7 @@ export class DiscordBot {
                         msgtype,
                         url: content.mxcUrl,
                     });
+                    this.lastEventIds[room] = res.event_id;
                     const evt = new DbEvent();
                     evt.MatrixId = `${res.event_id};${room}`;
                     evt.DiscordId = msg.id;
@@ -671,6 +677,7 @@ export class DiscordBot {
                     msgtype: result.msgtype,
                 });
                 const afterSend = async (re) => {
+                    this.lastEventIds[room] = re.event_id;
                     const evt = new DbEvent();
                     evt.MatrixId = `${re.event_id};${room}`;
                     evt.DiscordId = msg.id;
@@ -705,9 +712,17 @@ export class DiscordBot {
         log.info(`Got edit event for ${newMsg.id}`);
         let link = "";
         const storeEvent = await this.store.Get(DbEvent, {discord_id: oldMsg.id});
-        if (storeEvent && storeEvent.Result && storeEvent.Next()) {
-            const matrixIds = storeEvent.MatrixId.split(";");
-            link = `https://matrix.to/#/${matrixIds[1]}/${matrixIds[0]}`;
+        if (storeEvent && storeEvent.Result) {
+            while (storeEvent.Next()) {
+                const matrixIds = storeEvent.MatrixId.split(";");
+                if (matrixIds[0] === this.lastEventIds[matrixIds[1]]) {
+                    log.info("Immediate edit, deleting and re-sending");
+                    await this.DeleteDiscordMessage(oldMsg);
+                    await this.OnMessage(newMsg);
+                    return;
+                }
+                link = `https://matrix.to/#/${matrixIds[1]}/${matrixIds[0]}`;
+            }
         }
 
         // Create a new edit message using the old and new message contents

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -702,9 +702,16 @@ export class DiscordBot {
         if (oldMsg.content === newMsg.content) {
             return;
         }
+        log.info(`Got edit event for ${newMsg.id}`);
+        let link = "";
+        const storeEvent = await this.store.Get(DbEvent, {discord_id: oldMsg.id});
+        if (storeEvent && storeEvent.Result && storeEvent.Next()) {
+            const matrixIds = storeEvent.MatrixId.split(";");
+            link = `https://matrix.to/#/${matrixIds[1]}/${matrixIds[0]}`;
+        }
 
         // Create a new edit message using the old and new message contents
-        const editedMsg = await this.discordMsgProcessor.FormatEdit(oldMsg, newMsg);
+        const editedMsg = await this.discordMsgProcessor.FormatEdit(oldMsg, newMsg, link);
 
         // Send the message to all bridged matrix rooms
         if (!await this.SendMatrixMessage(editedMsg, newMsg.channel, newMsg.guild, newMsg.author, newMsg.id)) {

--- a/src/discordmessageprocessor.ts
+++ b/src/discordmessageprocessor.ts
@@ -13,6 +13,7 @@ const NAME_MXC_INSERT_REGEX_GROUP = 1;
 const ANIMATED_MXC_INSERT_REGEX_GROUP = 2;
 const ID_MXC_INSERT_REGEX_GROUP = 3;
 const EMOJI_SIZE = 32;
+const MAX_EDIT_MSG_LENGTH = 50;
 
 export class DiscordMessageProcessorOpts {
     constructor(readonly domain: string, readonly bot?: DiscordBot) {
@@ -81,7 +82,6 @@ export class DiscordMessageProcessor {
         newMsg: Discord.Message,
         link?: string,
     ): Promise<DiscordMessageProcessorResult> {
-        // https://matrix.to/#/!room/$event
         oldMsg.embeds = []; // we don't want embeds on old msg
         const oldMsgParsed = await this.FormatMessage(oldMsg);
         const newMsgParsed = await this.FormatMessage(newMsg);
@@ -91,8 +91,8 @@ export class DiscordMessageProcessor {
         oldMsg.content = `*edit:* ~~${oldMsg.content}~~ -> ${newMsg.content}`;
         const linkStart = link ? `<a href="${escapeHtml(link)}">` : "";
         const linkEnd = link ? "</a>" : "";
-        const MAX_MSG_LENGTH = 50;
-        if (oldMsg.content.includes("\n") || newMsg.content.includes("\n") || newMsg.content.length > MAX_MSG_LENGTH) {
+        if (oldMsg.content.includes("\n") || newMsg.content.includes("\n")
+            || newMsg.content.length > MAX_EDIT_MSG_LENGTH) {
             result.formattedBody = `<p>${linkStart}<em>edit:</em>${linkEnd}</p><p><del>${oldMsgParsed.formattedBody}` +
                 `</del></p><hr><p>${newMsgParsed.formattedBody}</p>`;
         } else {

--- a/test/test_discordbot.ts
+++ b/test/test_discordbot.ts
@@ -135,6 +135,7 @@ describe("DiscordBot", () => {
                 config,
                 mockBridge,
             );
+            discordBot.store.Get = (a, b) => null;
 
             const guild: any = new MockGuild("123", []);
             guild._mockAddMember(new MockMember("12345", "TestUsername"));

--- a/test/test_discordbot.ts
+++ b/test/test_discordbot.ts
@@ -129,7 +129,6 @@ describe("DiscordBot", () => {
             await discordBot.OnMessageUpdate(oldMsg, newMsg);
             Chai.assert.equal(checkMsgSent, false);
         });
-
         it("should send a matrix message on an edited discord message", async () => {
             discordBot = new modDiscordBot.DiscordBot(
                 config,
@@ -155,6 +154,39 @@ describe("DiscordBot", () => {
 
             await discordBot.OnMessageUpdate(oldMsg, newMsg);
             Chai.assert.equal(checkMsgSent, true);
+        });
+        it("should delete and re-send if it is the newest message", async () => {
+            discordBot = new modDiscordBot.DiscordBot(
+                config,
+                mockBridge,
+            );
+            discordBot.store.Get = (a, b) => { return {
+                MatrixId: "$event:localhost;!room:localhost",
+                Next: () => true,
+                Result: true,
+            }; };
+            discordBot.lastEventIds["!room:localhost"] = "$event:localhost";
+
+            const guild: any = new MockGuild("123", []);
+            guild._mockAddMember(new MockMember("12345", "TestUsername"));
+            const channel = new Discord.TextChannel(guild, {} as any);
+            const oldMsg = new MockMessage(channel) as any;
+            const newMsg = new MockMessage(channel) as any;
+            oldMsg.embeds = [];
+            newMsg.embeds = [];
+
+            // Content updated and edited
+            oldMsg.content = "a";
+            newMsg.content = "b";
+
+            let deletedMessage = false;
+            discordBot.DeleteDiscordMessage = async (_) => { deletedMessage = true; };
+            let sentMessage = false;
+            discordBot.OnMessage = async (_) => { sentMessage = true; };
+
+            await discordBot.OnMessageUpdate(oldMsg, newMsg);
+            Chai.assert.equal(deletedMessage, true);
+            Chai.assert.equal(sentMessage, true);
         });
     });
     describe("event:message", () => {

--- a/test/test_discordmessageprocessor.ts
+++ b/test/test_discordmessageprocessor.ts
@@ -186,7 +186,6 @@ describe("DiscordMessageProcessor", () => {
             Chai.assert.equal(result.body, "*edit:* ~~a~~ -> b");
             Chai.assert.equal(result.formattedBody, "<em>edit:</em> <del>a</del> -&gt; b");
         });
-
         it("should format markdown heavy edits apropriately", async () => {
             const processor = new DiscordMessageProcessor(
                 new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
@@ -204,7 +203,56 @@ describe("DiscordMessageProcessor", () => {
             Chai.assert.equal(result.formattedBody, "<em>edit:</em> <del>a slice of <strong>" +
               "cake</strong></del> -&gt; <em>a</em> slice of cake");
         });
+        it("should format discord fail edits correctly", async () => {
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
+            const oldMsg = new MockMessage() as any;
+            const newMsg = new MockMessage() as any;
+            oldMsg.embeds = [];
+            newMsg.embeds = [];
 
+            // Content updated but not changed
+            oldMsg.content = "~~fail~";
+            newMsg.content = "~~fail~~";
+
+            const result = await processor.FormatEdit(oldMsg, newMsg);
+            Chai.assert.equal(result.body, "*edit:* ~~~~fail~~~ -> ~~fail~~");
+            Chai.assert.equal(result.formattedBody, "<em>edit:</em> <del>~~fail~</del> -&gt; <del>fail</del>");
+        });
+        it("should format multiline edits correctly", async () => {
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
+            const oldMsg = new MockMessage() as any;
+            const newMsg = new MockMessage() as any;
+            oldMsg.embeds = [];
+            newMsg.embeds = [];
+
+            // Content updated but not changed
+            oldMsg.content = "multi\nline";
+            newMsg.content = "multi\nline\nfoxies";
+
+            const result = await processor.FormatEdit(oldMsg, newMsg);
+            Chai.assert.equal(result.body, "*edit:* ~~multi\nline~~ -> multi\nline\nfoxies");
+            Chai.assert.equal(result.formattedBody, "<p><em>edit:</em></p><p><del>multi<br>line</del></p><hr>" +
+                "<p>multi<br>line<br>foxies</p>");
+        });
+        it("should add old message link", async () => {
+            const processor = new DiscordMessageProcessor(
+                new DiscordMessageProcessorOpts("localhost"), bot as DiscordBot);
+            const oldMsg = new MockMessage() as any;
+            const newMsg = new MockMessage() as any;
+            oldMsg.embeds = [];
+            newMsg.embeds = [];
+
+            // Content updated but not changed
+            oldMsg.content = "fox";
+            newMsg.content = "foxies";
+
+            const result = await processor.FormatEdit(oldMsg, newMsg, "https://matrix.to/#/old");
+            Chai.assert.equal(result.body, "*edit:* ~~fox~~ -> foxies");
+            Chai.assert.equal(result.formattedBody, "<a href=\"https://matrix.to/#/old\"><em>edit:</em></a>" +
+                " <del>fox</del> -&gt; foxies");
+        });
     });
 
     describe("InsertUser / HTML", () => {


### PR DESCRIPTION
long and multiline edits look nicer now.
All edits include a link to their previous event
Immediate edits (edits without a message in between) delete the old message and re-send the current one

this is how long edits look like:
![screenshot_2018-12-24_15-43-18](https://user-images.githubusercontent.com/2433620/50401961-e3348380-0792-11e9-8f25-4b427600b119.png)

Implements #349 and #320