### PR TITLE
Send read receipts for successfully bridged Matrix events

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -24,6 +24,9 @@ bridge:
   # Enable users to bridge rooms using !discord commands. See
   # https://t2bot.io/discord for instructions.
   enableSelfServiceBridging: false
+  # Disable sending of read receipts for Matrix events which have been
+  # successfully bridged to Discord.
+  disableReadReceipts: false
 # Authentication configuration for the discord bot.
 auth:
   clientID: "12345"

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -20,6 +20,8 @@ properties:
             type: "boolean"
           enableSelfServiceBridging:
             type: "boolean"
+          disableReadReceipts:
+            type: "boolean"
     auth:
         type: "object"
         required: ["botToken", "clientID"]

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -323,7 +323,7 @@ export class DiscordBot {
         });
         if (!this.config.bridge.disableReadReceipts) {
             try {
-                await this.bridge.getIntent().sendReadReceipt(event.room_id, event.event_id)
+                await this.bridge.getIntent().sendReadReceipt(event.room_id, event.event_id);
             } catch (err) {
                 log.error(`Failed to send read receipt for ${event}. `, err);
             }
@@ -402,7 +402,7 @@ export class DiscordBot {
         });
         if (!this.config.bridge.disableReadReceipts) {
             try {
-                await this.bridge.getIntent().sendReadReceipt(event.room_id, event.event_id)
+                await this.bridge.getIntent().sendReadReceipt(event.room_id, event.event_id);
             } catch (err) {
                 log.error(`Failed to send read receipt for ${event}. `, err);
             }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -322,7 +322,11 @@ export class DiscordBot {
             await this.store.Insert(evt);
         });
         if (!this.config.bridge.disableReadReceipts) {
-            await this.bridge.getIntent().sendReadReceipt(event.room_id, event.event_id)
+            try {
+                await this.bridge.getIntent().sendReadReceipt(event.room_id, event.event_id)
+            } catch (err) {
+                log.error(`Failed to send read receipt for ${event}. `, err);
+            }
         }
     }
 
@@ -397,7 +401,11 @@ export class DiscordBot {
             await this.store.Insert(evt);
         });
         if (!this.config.bridge.disableReadReceipts) {
-            await this.bridge.getIntent().sendReadReceipt(event.room_id, event.event_id)
+            try {
+                await this.bridge.getIntent().sendReadReceipt(event.room_id, event.event_id)
+            } catch (err) {
+                log.error(`Failed to send read receipt for ${event}. `, err);
+            }
         }
         return;
     }

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -321,6 +321,9 @@ export class DiscordBot {
             evt.ChannelId = channel.id;
             await this.store.Insert(evt);
         });
+        if (!this.config.bridge.disableReadReceipts) {
+            await this.bridge.getIntent().sendReadReceipt(event.room_id, event.event_id)
+        }
     }
 
     public async ProcessMatrixMsgEvent(event: IMatrixEvent, guildId: string, channelId: string): Promise<void> {
@@ -393,6 +396,9 @@ export class DiscordBot {
             evt.ChannelId = channelId;
             await this.store.Insert(evt);
         });
+        if (!this.config.bridge.disableReadReceipts) {
+            await this.bridge.getIntent().sendReadReceipt(event.room_id, event.event_id)
+        }
         return;
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,6 +35,7 @@ class DiscordBridgeConfigBridge {
     public disableDiscordMentions: boolean;
     public disableDeletionForwarding: boolean;
     public enableSelfServiceBridging: boolean;
+    public disableReadReceipts: boolean;
     public disableEveryoneMention: boolean = false;
     public disableHereMention: boolean = false;
 }


### PR DESCRIPTION
Not sure what the policy on unit tests is but there weren't any for the two methods I changed, so I didn't add any.

Closes #326