### PR TITLE
escape pipe M->D

### DIFF
--- a/src/matrixmessageprocessor.ts
+++ b/src/matrixmessageprocessor.ts
@@ -94,7 +94,7 @@ export class MatrixMessageProcessor {
                 msg = msg.replace(/@room/g, "@here");
             }
         }
-        const escapeChars = ["\\", "*", "_", "~", "`"];
+        const escapeChars = ["\\", "*", "_", "~", "`", "|"];
         msg = msg.split(" ").map((s) => {
             if (s.match(/^https?:\/\//)) {
                 return s;

--- a/test/test_matrixmessageprocessor.ts
+++ b/test/test_matrixmessageprocessor.ts
@@ -98,6 +98,13 @@ describe("MatrixMessageProcessor", () => {
             const result = await mp.FormatMessage(msg, guild as any);
             expect(result).is.equal("wow \\\\\\*this\\\\\\* is cool");
         });
+        it("escapes ALL the stuff", async () => {
+            const mp = new MatrixMessageProcessor(bot);
+            const guild = new MockGuild("1234");
+            const msg = getPlainMessage("\\ * _ ~ ` |");
+            const result = await mp.FormatMessage(msg, guild as any);
+            expect(result).is.equal("\\\\ \\* \\_ \\~ \\` \\|");
+        });
     });
     describe("FormatMessage / formatted_body / simple", () => {
         it("leaves blank stuff untouched", async () => {


### PR DESCRIPTION
Discord introduces a new custom markdown, that is spoilers so that `in messages like ||this|| that this would be a spoiler`. OFC that means that, when sending messages M->D now we need to escape the pipe symbol.

Yay for discord being disocrd!