### PR TITLE
Point "new application" link a bit higher up since it doesn't work anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ should show up in the network list on Riot and other clients.
 
 ### Setting up Discord
 
-* Create a new application via https://discordapp.com/developers/applications/me/create
+* Create a new application via https://discordapp.com/developers/applications/
 * Make sure to create a bot user. Fill in ``config.yaml``
 * Run ``npm run getbotlink`` to get a authorisation link.
 * Give this link to owners of the guilds you plan to bridge.


### PR DESCRIPTION
Following the link for creating a new application actually results in

> Application not found!
> There was no application found with ID create.

This error page has no clear way to actually create an application. Going up to https://discordapp.com/developers/applications/, there's at least a button in the top-right for "New Application".