### PR TITLE
Drop support for node 8, start supporting 10 and 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,24 +2,18 @@ language: node_js
 install: npm install && npm run build
 
 jobs:
-    include:
-    - stage: tests
-      name: "Unit - Node 8"
-      script: npm run test
-      node_js: "8"
     - script: npm run test
       name: "Unit - Node 10"
       node_js: "10"
     - script: npm run test
-      name: "Unit - Node 11"
-      node_js: "11.0.0"
-
+      name: "Unit - Node 12"
+      node_js: "12"
     - script: npm run lint
       name: "Linting"
-      node_js: "10"
+      node_js: "12"
     - script: npm run coverage
       name: "Coverage"
-      node_js: "10"
+      node_js: "12"
 
 notifications:
     webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: node_js
 install: npm install && npm run build
+node_js:
+    - "10"
+    - "12"
 
 jobs:
     - script: npm run test

--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ Please also be aware that this is an unoffical project worked on in my (Half-Sho
 
 ## Setting up
 
-These instructions were tested against Node.js v8.11.1 and the Synapse homeserver.
+The bridge has been tested against the [Synapse](https://github.com/matrix-org/synapse) homeserver, although any homeserver
+that implements the [AS API](https://matrix.org/docs/spec/application_service/r0.1.0.html) should work with this bridge.
+
+The bridge supports any version of Node.js >= v10.X, including all [current releases](https://nodejs.org/en/about/releases/).
 
 ### Setup the bridge
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1206,7 +1206,7 @@
     },
     "finalhandler": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
       "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
       "requires": {
         "debug": "2.6.9",

--- a/test/test_matrixeventprocessor.ts
+++ b/test/test_matrixeventprocessor.ts
@@ -610,7 +610,7 @@ describe("MatrixEventProcessor", () => {
                     info: {
                         mimetype: "image/png",
                     },
-                    url: "mxc://bunny",
+                    url: "mxc://bunny/500",
                 },
                 sender: "@test:localhost",
                 type: "m.sticker",


### PR DESCRIPTION
Also make clear in the README that we support more than one version of node, which has confused folks before.