### PR TITLE
Fix docker image for appservice bridge dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:alpine AS BUILD
 COPY . /tmp/src
 # install some dependencies needed for the build process
-RUN apk add --no-cache -t build-deps make gcc g++ python ca-certificates libc-dev wget
+RUN apk add --no-cache -t build-deps make gcc g++ python ca-certificates libc-dev wget git
 RUN cd /tmp/src \
     && npm install \
     && npm run build


### PR DESCRIPTION
It uses a git reference, but the image doesn't have git