### PR TITLE
Add debug command to npm package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "coverage": "tsc && nyc mocha",
     "build": "tsc",
     "start": "npm run-script build && node ./build/src/discordas.js -p 9005 -c config.yaml",
+    "debug": "npm run-script build && node --inspect ./build/src/discordas.js -p 9005 -c config.yaml",
     "addbot": "node ./build/tools/addbot.js",
     "adminme": "node ./build/tools/adminme.js",
     "usertool": "node ./build/tools/userClientTools.js",


### PR DESCRIPTION
Add new command `npm run debug` to start the bridge with inspection enabled. This makes it faster to debug the bridge.

Signed-off-by: Kai A. Hiller <V02460@gmail.com>