### PR TITLE
tools: parameterise config file paths

### DIFF
--- a/docs/howto.md
+++ b/docs/howto.md
@@ -15,7 +15,7 @@ is formatted as https://discordapp.com/channels/``guildid``/``channelid``
 
 * The ``adminme`` script is provided to set Admin/Moderator or any other custom power level to a specific user.
 * e.g. To set Alice to Admin on her ``example.com`` HS on default config. (``config.yaml``)
-  * ``npm run adminme -- -r '!AbcdefghijklmnopqR:example.com' -u '@Alice:example.com' -p '100'``
+  * ``npm run adminme -- -m '!AbcdefghijklmnopqR:example.com' -u '@Alice:example.com' -p '100'``
   * Run ``npm run adminme -- -h`` for usage.
 
 Please note that `!AbcdefghijklmnopqR:example.com` is the internal room id and will always begin with `!`.

--- a/tools/addRoomsToDirectory.ts
+++ b/tools/addRoomsToDirectory.ts
@@ -45,6 +45,14 @@ const optionDefinitions = [
         typeLabel: "<config.yaml>",
     },
     {
+        alias: "r",
+        defaultValue: "discord-registration.yaml",
+        description: "The AS registration file.",
+        name: "registration",
+        type: String,
+        typeLabel: "<discord-registration.yaml>",
+    },
+    {
         alias: "s",
         defaultValue: "room-store.db",
         description: "The location of the room store.",
@@ -69,7 +77,7 @@ if (options.help) {
     ]));
     process.exit(0);
 }
-const yamlConfig = yaml.safeLoad(fs.readFileSync("./discord-registration.yaml", "utf8"));
+const yamlConfig = yaml.safeLoad(fs.readFileSync(options.registration, "utf8"));
 const registration = AppServiceRegistration.fromObject(yamlConfig);
 const config: DiscordBridgeConfig = yaml.safeLoad(fs.readFileSync(options.config, "utf8")) as DiscordBridgeConfig;
 

--- a/tools/addbot.ts
+++ b/tools/addbot.ts
@@ -20,9 +20,45 @@ limitations under the License.
  */
 import * as yaml from "js-yaml";
 import * as fs from "fs";
+import * as args from "command-line-args";
+import * as usage from "command-line-usage";
 import { Util } from "../src/util";
 
-const yamlConfig = yaml.safeLoad(fs.readFileSync("config.yaml", "utf8"));
+const optionDefinitions = [
+  {
+      alias: "h",
+      description: "Display this usage guide.",
+      name: "help",
+      type: Boolean,
+  },
+  {
+      alias: "c",
+      defaultValue: "config.yaml",
+      description: "The AS config file.",
+      name: "config",
+      type: String,
+      typeLabel: "<config.yaml>",
+  },
+];
+
+const options = args(optionDefinitions);
+
+if (options.help) {
+  /* tslint:disable:no-console */
+  console.log(usage([
+  {
+      content: "A tool to obtain the Discord bot invitation URL.",
+      header: "Add bot",
+  },
+  {
+      header: "Options",
+      optionList: optionDefinitions,
+  },
+  ]));
+  process.exit(0);
+}
+
+const yamlConfig = yaml.safeLoad(fs.readFileSync(options.config, "utf8"));
 if (yamlConfig === null) {
   console.error("You have an error in your discord config.");
 }

--- a/tools/adminme.ts
+++ b/tools/adminme.ts
@@ -43,6 +43,14 @@ const optionDefinitions = [
     },
     {
         alias: "r",
+        defaultValue: "discord-registration.yaml",
+        description: "The AS registration file.",
+        name: "registration",
+        type: String,
+        typeLabel: "<discord-registration.yaml>",
+    },
+    {
+        alias: "m",
         description: "The roomid to modify",
         name: "roomid",
         type: String,
@@ -90,7 +98,7 @@ if (!options.userid) {
     process.exit(1);
 }
 
-const yamlConfig = yaml.safeLoad(fs.readFileSync("discord-registration.yaml", "utf8"));
+const yamlConfig = yaml.safeLoad(fs.readFileSync(options.registration, "utf8"));
 const registration = AppServiceRegistration.fromObject(yamlConfig);
 const config: DiscordBridgeConfig = yaml.safeLoad(fs.readFileSync(options.config, "utf8")) as DiscordBridgeConfig;
 

--- a/tools/chanfix.ts
+++ b/tools/chanfix.ts
@@ -44,6 +44,14 @@ const optionDefinitions = [
         type: String,
         typeLabel: "<config.yaml>",
     },
+    {
+        alias: "r",
+        defaultValue: "discord-registration.yaml",
+        description: "The AS registration file.",
+        name: "registration",
+        type: String,
+        typeLabel: "<discord-registration.yaml>",
+    },
 ];
 
 const options = args(optionDefinitions);
@@ -64,7 +72,7 @@ if (options.help) {
     process.exit(0);
 }
 
-const yamlConfig = yaml.safeLoad(fs.readFileSync("./discord-registration.yaml", "utf8"));
+const yamlConfig = yaml.safeLoad(fs.readFileSync(options.registration, "utf8"));
 const registration = AppServiceRegistration.fromObject(yamlConfig);
 const config = new DiscordBridgeConfig();
 config.applyConfig(yaml.safeLoad(fs.readFileSync(options.config, "utf8")) as DiscordBridgeConfig);

--- a/tools/ghostfix.ts
+++ b/tools/ghostfix.ts
@@ -53,6 +53,14 @@ const optionDefinitions = [
         type: String,
         typeLabel: "<config.yaml>",
     },
+    {
+        alias: "r",
+        defaultValue: "discord-registration.yaml",
+        description: "The AS registration file.",
+        name: "registration",
+        type: String,
+        typeLabel: "<discord-registration.yaml>",
+    },
 ];
 
 const options = args(optionDefinitions);
@@ -73,7 +81,7 @@ if (options.help) {
     process.exit(0);
 }
 
-const yamlConfig = yaml.safeLoad(fs.readFileSync("./discord-registration.yaml", "utf8"));
+const yamlConfig = yaml.safeLoad(fs.readFileSync(options.registration, "utf8"));
 const registration = AppServiceRegistration.fromObject(yamlConfig);
 const config = new DiscordBridgeConfig();
 config.applyConfig(yaml.safeLoad(fs.readFileSync(options.config, "utf8")) as DiscordBridgeConfig);


### PR DESCRIPTION
PR solving https://github.com/Half-Shot/matrix-appservice-discord/issues/507 (Hard-coded configuration paths in tools).

Changes compile, pass the lint and unit tests, but __weren't tested manually__.

