### PR TITLE
switch to lock class

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -85,10 +85,12 @@ channel:
 limits:
     # Delay in milliseconds between discord users joining a room.
     roomGhostJoinDelay: 6000
-    # Delay in milliseconds before sending messages to discord to avoid echos.
-    # (Copies of a sent message may arrive from discord before we've
+    # Lock timeout in milliseconds before seinding messages to discord to avoid
+    # echos. Default is rather high as the lock will most likely time out
+    # before anyways.
+    # echos = (Copies of a sent message may arrive from discord before we've
     # fininished handling it, causing us to echo it back to the room)
-    discordSendDelay: 750
+    discordSendDelay: 1500
 ghosts:
     # Pattern for the ghosts nick, available is :nick, :username, :tag and :id
     nickPattern: ":nick"

--- a/src/config.ts
+++ b/src/config.ts
@@ -133,7 +133,7 @@ export class DiscordBridgeConfigChannelDeleteOptions {
 
 class DiscordBridgeConfigLimits {
     public roomGhostJoinDelay: number = 6000;
-    public discordSendDelay: number = 750;
+    public discordSendDelay: number = 1500;
 }
 
 export class LoggingFile {

--- a/src/structures/lock.ts
+++ b/src/structures/lock.ts
@@ -1,0 +1,60 @@
+export class Lock<T> {
+    private locks: Map<T, {i: NodeJS.Timeout|null, r: (() => void)|null}>;
+    private lockPromises: Map<T, Promise<{}>>;
+    constructor(
+        private timeout: number,
+    ) {
+        this.locks = new Map();
+        this.lockPromises = new Map();
+    }
+
+    public set(key: T) {
+        // if there is a lock set.....we don't set a second one ontop
+        if (this.locks.has(key)) {
+            return;
+        }
+
+        // set a dummy lock so that if we re-set again before releasing it won't do anthing
+        this.locks.set(key, {i: null, r: null});
+
+        const p = new Promise<{}>((resolve) => {
+            // first we check if the lock has the key....if not, e.g. if it
+            // got released too quickly, we still want to resolve our promise
+            if (!this.locks.has(key)) {
+                resolve();
+                return;
+            }
+            // create the interval that will release our promise after the timeout
+            const i = setTimeout(() => {
+                this.release(key);
+            }, this.timeout);
+            // aaand store to our lock
+            this.locks.set(key, {r: resolve, i});
+        });
+        this.lockPromises.set(key, p);
+    }
+
+    public release(key: T) {
+        // if there is nothing to release then there is nothing to release
+        if (!this.locks.has(key)) {
+            return;
+        }
+        const lock = this.locks.get(key)!;
+        if (lock.r !== null) {
+            lock.r();
+        }
+        if (lock.i !== null) {
+            clearTimeout(lock.i);
+        }
+        this.locks.delete(key);
+        this.lockPromises.delete(key);
+    }
+
+    public async wait(key: T) {
+        // we wait for a lock release only if a promise is present
+        const promise = this.lockPromises.get(key);
+        if (promise) {
+            await promise;
+        }
+    }
+}

--- a/test/structures/test_lock.ts
+++ b/test/structures/test_lock.ts
@@ -1,0 +1,45 @@
+/*
+Copyright 2019 matrix-appservice-discord
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { expect } from "chai";
+import { Lock } from "../../src/structures/lock";
+import { Util } from "../../src/util";
+
+const LOCKTIMEOUT = 300;
+
+describe("Lock", () => {
+    it("should lock and unlock", async () => {
+        const lock = new Lock<string>(LOCKTIMEOUT);
+        const t = Date.now();
+        lock.set("bunny");
+        await lock.wait("bunny");
+        const diff = Date.now() - t;
+        expect(diff).to.be.greaterThan(LOCKTIMEOUT - 1);
+    });
+    it("should lock and unlock early, if unlocked", async () => {
+        const SHORTDELAY = 100;
+        const DELAY_ACCURACY = 5;
+        const lock = new Lock<string>(LOCKTIMEOUT);
+        setTimeout(() => lock.release("fox"), SHORTDELAY);
+        const t = Date.now();
+        lock.set("fox");
+        await lock.wait("fox");
+        const diff = Date.now() - t;
+        // accuracy can be off by a few ms soemtimes
+        expect(diff).to.be.greaterThan(SHORTDELAY - DELAY_ACCURACY);
+        expect(diff).to.be.lessThan(SHORTDELAY + DELAY_ACCURACY);
+    });
+});

--- a/test/test_discordbot.ts
+++ b/test/test_discordbot.ts
@@ -416,48 +416,6 @@ describe("DiscordBot", () => {
             assert.equal(expected, ITERATIONS);
         });
     });
-    describe("locks", () => {
-        it("should lock and unlock a channel", async () => {
-            const bot = new modDiscordBot.DiscordBot(
-                "",
-                config,
-                mockBridge,
-                {},
-            ) as DiscordBot;
-            const chan = new MockChannel("123") as any;
-            const t = Date.now();
-            bot.lockChannel(chan);
-            await bot.waitUnlock(chan);
-            const diff = Date.now() - t;
-            expect(diff).to.be.greaterThan(config.limits.discordSendDelay - 1);
-        });
-        it("should lock and unlock a channel early, if unlocked", async () => {
-            const discordSendDelay = 500;
-            const SHORTDELAY = 100;
-            const MINEXPECTEDDELAY = 95;
-            const bot = new modDiscordBot.DiscordBot(
-                "",
-                {
-                    bridge: {
-                        domain: "localhost",
-                    },
-                    limits: {
-                        discordSendDelay,
-                    },
-                },
-                mockBridge,
-                {},
-            ) as DiscordBot;
-            const chan = new MockChannel("123") as any;
-            setTimeout(() => bot.unlockChannel(chan), SHORTDELAY);
-            const t = Date.now();
-            bot.lockChannel(chan);
-            await bot.waitUnlock(chan);
-            const diff = Date.now() - t;
-            // Date accuracy can be off by a few ms sometimes.
-            expect(diff).to.be.greaterThan(MINEXPECTEDDELAY);
-        });
-    });
   // });
     // describe("ProcessMatrixMsgEvent()", () => {
     //


### PR DESCRIPTION
Switches to a separate lock class, as briefly discussed in the channel.

Also increases the default for sendDelay as it is more a lock timeout now, and thus should never be reached anyways

Possibly fixes the bug where puppets sometimes echo back what they say