### PR TITLE
Correct spelling of 'insufficiant' to 'insufficient'

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -321,7 +321,7 @@ export class Util {
                 return `**ERROR:** ${permCheck}`;
             }
             if (!permCheck) {
-                return `**ERROR:** insufficiant permissions to use this command! ` +
+                return `**ERROR:** insufficient permissions to use this command! ` +
                     `Try \`${prefix} help\` to see all available commands`;
             }
         }

--- a/test/test_matrixcommandhandler.ts
+++ b/test/test_matrixcommandhandler.ts
@@ -157,7 +157,7 @@ describe("MatrixCommandHandler", () => {
                 power: false,
             });
             await handler.Process(createEvent("!discord bridge"), createContext());
-            expect(MESSAGESENT.body).to.equal("**ERROR:** insufficiant permissions to use this " +
+            expect(MESSAGESENT.body).to.equal("**ERROR:** insufficient permissions to use this " +
                 "command! Try `!discord help` to see all available commands");
         });
         describe("!discord bridge", () => {


### PR DESCRIPTION
Fixes #558 

Fixes spelling of 'insufficient' in src/util.ts and test/test_matrixcommandhandler.ts.