### PR TITLE
Add uuid (missing as a direct dependency)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,11 +51,13 @@
     "p-queue": "^6.4.0",
     "pg-promise": "^10.5.6",
     "prom-client": "^12.0.0",
+    "uuid": "^8.3.1",
     "winston": "^3.2.1",
     "winston-daily-rotate-file": "^4.5.0"
   },
   "devDependencies": {
     "@istanbuljs/nyc-config-typescript": "^1.0.1",
+    "@types/better-sqlite3": "^5.4.1",
     "@types/chai": "^4.2.11",
     "@types/command-line-args": "^5.0.0",
     "@types/js-yaml": "^3.12.4",
@@ -63,7 +65,6 @@
     "@types/mime": "^2.0.2",
     "@types/mocha": "^7.0.2",
     "@types/node": "^12",
-    "@types/better-sqlite3": "^5.4.1",
     "chai": "^4.2.0",
     "mocha": "^8.0.1",
     "nyc": "^15.1.0",

--- a/src/db/roomstore.ts
+++ b/src/db/roomstore.ts
@@ -17,7 +17,7 @@ import { Log } from "../log";
 import { IDatabaseConnector } from "./connector";
 import { Util } from "../util";
 
-import { v4 as uuid } from 'uuid';
+import { v4 as uuid } from "uuid";
 import { MetricPeg } from "../metrics";
 import { TimedCache } from "../structures/timedcache";
 

--- a/src/db/roomstore.ts
+++ b/src/db/roomstore.ts
@@ -17,7 +17,7 @@ import { Log } from "../log";
 import { IDatabaseConnector } from "./connector";
 import { Util } from "../util";
 
-import * as uuid from "uuid/v4";
+import { v4 as uuid } from 'uuid';
 import { MetricPeg } from "../metrics";
 import { TimedCache } from "../structures/timedcache";
 

--- a/src/discordas.ts
+++ b/src/discordas.ts
@@ -23,7 +23,7 @@ import { Log } from "./log";
 import "source-map-support/register";
 import * as cliArgs from "command-line-args";
 import * as usage from "command-line-usage";
-import * as uuid from "uuid/v4";
+import { v4 as uuid } from 'uuid';
 import { IMatrixEvent } from "./matrixtypes";
 import { MetricPeg, PrometheusBridgeMetrics } from "./metrics";
 

--- a/src/discordas.ts
+++ b/src/discordas.ts
@@ -23,7 +23,7 @@ import { Log } from "./log";
 import "source-map-support/register";
 import * as cliArgs from "command-line-args";
 import * as usage from "command-line-usage";
-import { v4 as uuid } from 'uuid';
+import { v4 as uuid } from "uuid";
 import { IMatrixEvent } from "./matrixtypes";
 import { MetricPeg, PrometheusBridgeMetrics } from "./metrics";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3508,6 +3508,11 @@ uuid@^3.3.2, uuid@^3.3.3:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uuid@^8.3.1:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
+  integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
+
 vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"


### PR DESCRIPTION
* `uuid` is a direct dependency in the code but not listed in the `package.json`.
* [Deep requires got deprecated in uuid 8.x](https://www.npmjs.com/package/uuid#deep-requires-no-longer-supported)