### PR TITLE
Add metrics to the config sample and schema

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -104,3 +104,8 @@ ghosts:
     nickPattern: ":nick"
     # Pattern for the ghosts username, available is :username, :tag and :id
     usernamePattern: ":username#:tag"
+# Prometheus-compatible metrics endpoint
+metrics:
+    enabled: false
+    port: 9001
+    host: "localhost"

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -108,4 +108,4 @@ ghosts:
 metrics:
     enabled: false
     port: 9001
-    host: "localhost"
+    host: "127.0.0.1"

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -124,3 +124,12 @@ properties:
                 type: "string"
             usernamePattern:
                 type: "string"
+    metrics:
+        type: "object"
+        properties:
+            enabled:
+                type: "boolean"
+            port:
+                type: "number"
+            host:
+                type: "string"


### PR DESCRIPTION
The metrics endpoint would be easier to discover and configure if it was included in the config sample and schema.

The types are taken from here:
https://github.com/Half-Shot/matrix-appservice-discord/blob/3590fe4f3a28d228aeaf6e9e047938542dc86d2a/src/config.ts#L160-L164

I assume this was forgotten in #480.