### PR TITLE
Warn if the log level is invalid

### DIFF
--- a/src/log.ts
+++ b/src/log.ts
@@ -47,7 +47,7 @@ export class Log {
     private static logger: Logger;
 
     private static isValidLevel(level: string) {
-        return ['silly', 'verbose', 'info', 'http', 'warn', 'error', 'silent'].includes(level);
+        return ["silly", "verbose", "info", "http", "warn", "error", "silent"].includes(level);
     }
 
     private static setupLogger() {

--- a/src/log.ts
+++ b/src/log.ts
@@ -46,6 +46,10 @@ export class Log {
     private static config: DiscordBridgeConfigLogging;
     private static logger: Logger;
 
+    private static isValidLevel(level: string) {
+        return ['silly', 'verbose', 'info', 'http', 'warn', 'error', 'silent'].includes(level);
+    }
+
     private static setupLogger() {
         if (Log.logger) {
             Log.logger.close();
@@ -53,6 +57,9 @@ export class Log {
         const tsports: transports.StreamTransportInstance[] = Log.config.files.map((file) =>
             Log.setupFileTransport(file),
         );
+        if (Log.config.console && !Log.isValidLevel(Log.config.console)) {
+            new Log("Log").warn("Console log level is invalid. Please pick one of the case-sensitive levels provided in the sample config.");
+        }
         tsports.push(new transports.Console({
             level: Log.config.console,
         }));
@@ -79,6 +86,10 @@ export class Log {
             }
             return info;
         });
+
+        if (config.level && !Log.isValidLevel(config.level)) {
+            new Log("Log").warn(`Log level of ${config.file} is invalid. Please pick one of the case-sensitive levels provided in the sample config.`);
+        }
 
         const opts = {
             datePattern: config.datePattern,

--- a/test/test_log.ts
+++ b/test/test_log.ts
@@ -71,6 +71,24 @@ describe("Log", () => {
             expect(Log.config.files).to.not.be.empty;
             expect(Log.config.files[0].file).to.equal("./logfile.log");
         });
+        it("should warn if log level got misspelled", () => {
+            Log.Configure({
+                console: "WARNING",
+                lineDateFormat: "HH:mm:ss",
+            });
+            expect(loggedMessages).to.contain("Console log level is invalid. Please pick one of the case-sensitive levels provided in the sample config.");
+        });
+        it("should warn if log level for a file got misspelled", () => {
+            Log.Configure({
+                files: [
+                    {
+                        file: "./logfile.log",
+                        level: "WARNING",
+                    },
+                ],
+            });
+            expect(loggedMessages).to.contain("Log level of ./logfile.log is invalid. Please pick one of the case-sensitive levels provided in the sample config.");
+        });
     });
     describe("ForceSilent", () => {
         it("should be silent", () => {


### PR DESCRIPTION
Warns the bridge admin on the console, if any of the log levels are not valid.

This is a follow up on me thinking "WARN" was an ok log level. It had to be "warn" in order to work.