### PR TITLE
Remove unused parameter `provisioner` from MatrixRoomHandler

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -40,7 +40,7 @@ auth:
   # This MUST be a string (wrapped in quotes)
   clientID: "12345"
   botToken: "foobar"
-  # You must enable "Privileged Gateway Intents" in your bot settings on discord.com (e.g.g https://discord.com/developers/applications/12345/bot)
+  # You must enable "Privileged Gateway Intents" in your bot settings on discord.com (e.g. https://discord.com/developers/applications/12345/bot)
   # for this to work
   usePrivilegedIntents: false
 logging:

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -94,7 +94,7 @@ export class DiscordBot {
         this.clientFactory = new DiscordClientFactory(store, config.auth);
         this.discordMsgProcessor = new DiscordMessageProcessor(config.bridge.domain, this);
         this.presenceHandler = new PresenceHandler(this);
-        this.roomHandler = new MatrixRoomHandler(this, config, this.provisioner, bridge, store.roomStore);
+        this.roomHandler = new MatrixRoomHandler(this, config, bridge, store.roomStore);
         this.channelSync = new ChannelSyncroniser(bridge, config, this, store.roomStore);
         this.provisioner = new Provisioner(store.roomStore, this.channelSync);
         this.mxEventProcessor = new MatrixEventProcessor(

--- a/src/matrixroomhandler.ts
+++ b/src/matrixroomhandler.ts
@@ -19,7 +19,6 @@ import { DiscordBridgeConfig } from "./config";
 
 import * as Discord from "better-discord.js";
 import { Util } from "./util";
-import { Provisioner } from "./provisioner";
 import { Log } from "./log";
 const log = new Log("MatrixRoomHandler");
 import { DbRoomStore, MatrixStoreRoom, RemoteStoreRoom } from "./db/roomstore";
@@ -47,16 +46,12 @@ const JOIN_ROOM_SCHEDULE = [
 
 export class MatrixRoomHandler {
     private botUserId: string;
-    private botJoinedRooms: Set<string>; // roomids
-    private botJoinedRoomsCacheUpdatedAt = 0;
     constructor(
         private discord: DiscordBot,
         private config: DiscordBridgeConfig,
-        private provisioner: Provisioner,
         private bridge: Appservice,
         private roomStore: DbRoomStore) {
         this.botUserId = this.discord.BotUserId;
-        this.botJoinedRooms = new Set();
     }
 
     public bindThirdparty() {

--- a/test/test_matrixroomhandler.ts
+++ b/test/test_matrixroomhandler.ts
@@ -26,7 +26,7 @@ import { AppserviceMock } from "./mocks/appservicemock";
 // we are a test file and thus need those
 /* tslint:disable:no-unused-expression max-file-line-count no-any */
 
-const RoomHandler = (Proxyquire("../src/matrixroomhandler", {
+const MatrixRoomHandler = (Proxyquire("../src/matrixroomhandler", {
     "./util": {
         Util: {
             DelayedPromise: Util.DelayedPromise,
@@ -119,7 +119,7 @@ function createRH(opts: any = {}) {
 
         },
     };
-    const handler = new RoomHandler(bot as any, config, bridge as any, store);
+    const handler = new MatrixRoomHandler(bot as any, config, bridge as any, store);
     return { handler, bridge };
 }
 

--- a/test/test_matrixroomhandler.ts
+++ b/test/test_matrixroomhandler.ts
@@ -105,23 +105,6 @@ function createRH(opts: any = {}) {
     } else {
         config.bridge.enableSelfServiceBridging = true;
     }
-    const provisioner = {
-        AskBridgePermission: async () => {
-            if (opts.denyBridgePermission) {
-                throw new Error("The bridge has been declined by the Discord guild");
-            }
-        },
-        BridgeMatrixRoom: () => {
-            if (opts.failBridgeMatrix) {
-                throw new Error("Test failed matrix bridge");
-            }
-        },
-        UnbridgeRoom: async () => {
-            if (opts.failUnbridge) {
-                throw new Error("Test failed unbridge");
-            }
-        },
-    };
     const store = {
         getEntriesByMatrixId: (matrixId) => {
             return [{
@@ -136,7 +119,7 @@ function createRH(opts: any = {}) {
 
         },
     };
-    const handler = new RoomHandler(bot as any, config, provisioner as any, bridge as any, store);
+    const handler = new RoomHandler(bot as any, config, bridge as any, store);
     return { handler, bridge };
 }
 


### PR DESCRIPTION
TypeScript told me that this was unused code and I couldn't find it being used anywhere.

:warning: If this bridge/file is used as a library, this is API-breaking. That would require a new major version.