### PR TITLE
Fix syncing ghosts without avatars

### DIFF
--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -200,9 +200,9 @@ export class UserSyncroniser {
             return;
         }
         const remoteUser = await this.userStore.getRemoteUser(memberState.id);
-        let avatar = "";
+        let avatar: string|undefined;
         if (remoteUser) {
-            avatar = remoteUser.avatarurlMxc || "";
+            avatar = remoteUser.avatarurlMxc || undefined;
         } else {
             log.warn("Remote user wasn't found, using blank avatar");
         }

--- a/test/test_usersyncroniser.ts
+++ b/test/test_usersyncroniser.ts
@@ -328,7 +328,6 @@ describe("UserSyncroniser", () => {
             bridge.getIntentForUserId("@_discord_123456:localhost").underlyingClient.wasCalled(
                 "sendStateEvent", true, "!abc:localhost",
                 "m.room.member", "@_discord_123456:localhost", {
-                    "avatar_url": "",
                     "displayname": "Good Boy",
                     "membership": "join",
                     "uk.half-shot.discord.member": {


### PR DESCRIPTION
This should make certain clients, such as Element Android, less confused about these member events.