### PR TITLE
Add new setting to configure permission level required for bridging

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -35,10 +35,10 @@ bridge:
   disableInviteNotifications: false
   # Auto-determine the language of code blocks (this can be CPU-intensive)
   determineCodeLanguage: false
-  # By default user must have power_levels room permission to be able to bridge (usually PL100). 
-  # Set this if you want to allow bridging with only canonical_alias permission (usually PL50).
-  # For example portal IRC rooms have only PL50 available so this is useful for bridging them.
-  bridgingRequiresCanonicalAliasPermission: false
+  # Define room permission that user must have. Default is "uk.half-shot.bridge" but 
+  # you might want to use "m.room.power_levels" (old default) or "m.room.canonical_alias" (to allow bridging
+  # with PL50 on IRC portal rooms)
+  bridgingRequiresPermission: "uk.half-shot.bridge"
 # Authentication configuration for the discord bot.
 auth:
   # This MUST be a string (wrapped in quotes)

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -35,6 +35,10 @@ bridge:
   disableInviteNotifications: false
   # Auto-determine the language of code blocks (this can be CPU-intensive)
   determineCodeLanguage: false
+  # By default user must have power_levels room permission to be able to bridge (usually PL100). 
+  # Set this if you want to allow bridging with only canonical_alias permission (usually PL50).
+  # For example portal IRC rooms have only PL50 available so this is useful for bridging them.
+  bridgingRequiresCanonicalAliasPermission: false
 # Authentication configuration for the discord bot.
 auth:
   # This MUST be a string (wrapped in quotes)

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -28,8 +28,8 @@ properties:
             type: "boolean"
           disableInviteNotifications:
             type: "boolean"
-          bridgingRequiresCanonicalAliasPermission:
-            type: "boolean"
+          bridgingRequiresPermission:
+            type: "string"
     auth:
         type: "object"
         required: ["botToken", "clientID"]

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -28,6 +28,8 @@ properties:
             type: "boolean"
           disableInviteNotifications:
             type: "boolean"
+          bridgingRequiresCanonicalAliasPermission:
+            type: "boolean"
     auth:
         type: "object"
         required: ["botToken", "clientID"]

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,7 +95,7 @@ class DiscordBridgeConfigBridge {
     public disableJoinLeaveNotifications: boolean = false;
     public disableInviteNotifications: boolean = false;
     public determineCodeLanguage: boolean = false;
-    public bridgingRequiresCanonicalAliasPermission: boolean = false;
+    public bridgingRequiresPermission: string = "uk.half-shot.bridge";
 }
 
 export class DiscordBridgeConfigDatabase {

--- a/src/config.ts
+++ b/src/config.ts
@@ -95,6 +95,7 @@ class DiscordBridgeConfigBridge {
     public disableJoinLeaveNotifications: boolean = false;
     public disableInviteNotifications: boolean = false;
     public determineCodeLanguage: boolean = false;
+    public bridgingRequiresCanonicalAliasPermission: boolean = false;
 }
 
 export class DiscordBridgeConfigDatabase {

--- a/src/matrixcommandhandler.ts
+++ b/src/matrixcommandhandler.ts
@@ -75,7 +75,7 @@ export class MatrixCommandHandler {
                     cat: "events",
                     level: PROVISIONING_DEFAULT_POWER_LEVEL,
                     selfService: true,
-                    subcat: "m.room.power_levels",
+                    subcat: this.config.bridge.bridgingRequiresCanonicalAliasPermission ? "m.room.canonical_alias" : "m.room.power_levels",
                 },
                 run: async ({guildId, channelId}) => {
                     if (roomEntry && roomEntry.remote) {

--- a/src/matrixcommandhandler.ts
+++ b/src/matrixcommandhandler.ts
@@ -75,7 +75,7 @@ export class MatrixCommandHandler {
                     cat: "events",
                     level: PROVISIONING_DEFAULT_POWER_LEVEL,
                     selfService: true,
-                    subcat: this.config.bridge.bridgingRequiresCanonicalAliasPermission ? "m.room.canonical_alias" : "m.room.power_levels",
+                    subcat: this.config.bridge.bridgingRequiresPermission,
                 },
                 run: async ({guildId, channelId}) => {
                     if (roomEntry && roomEntry.remote) {

--- a/src/matrixcommandhandler.ts
+++ b/src/matrixcommandhandler.ts
@@ -117,7 +117,7 @@ export class MatrixCommandHandler {
                     cat: "events",
                     level: PROVISIONING_DEFAULT_POWER_LEVEL,
                     selfService: true,
-                    subcat: "m.room.power_levels",
+                    subcat: this.config.bridge.bridgingRequiresPermission,
                 },
                 run: async () => {
                     if (!roomEntry || !roomEntry.remote) {


### PR DESCRIPTION
Bridge admin can decide which room event permission level is checked for bridge permission. Sets uk.half-shot.bridge as default.