### PR TITLE
.substr() -> .substring()

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -340,7 +340,7 @@ export class DiscordBot {
 
     public ThirdpartySearchForChannels(guildId: string, channelName: string): IThirdPartyLookup[] {
         if (channelName.startsWith("#")) {
-            channelName = channelName.substr(1);
+            channelName = channelName.substring(1);
         }
         if (this.bot.guilds.cache.has(guildId) ) {
             const guild = this.bot.guilds.cache.get(guildId);

--- a/src/db/postgres.ts
+++ b/src/db/postgres.ts
@@ -26,7 +26,7 @@ const pgp: pgPromise.IMain = pgPromise({
 export class Postgres implements IDatabaseConnector {
     public static ParameterizeSql(sql: string): string {
         return sql.replace(/\$((\w|\d|_)+)+/g, (k) => {
-            return `\${${k.substr("$".length)}}`;
+            return `\${${k.substring("$".length)}}`;
         });
     }
 
@@ -37,7 +37,7 @@ export class Postgres implements IDatabaseConnector {
     }
     public Open() {
         // Hide username:password
-        const logConnString = this.connectionString.substr(
+        const logConnString = this.connectionString.substring(
             this.connectionString.indexOf("@") || 0,
         );
         log.info(`Opening ${logConnString}`);

--- a/src/matrixeventprocessor.ts
+++ b/src/matrixeventprocessor.ts
@@ -530,7 +530,7 @@ export class MatrixEventProcessor {
             }
         }
         embed.setAuthor(
-            displayName.substr(0, MAX_NAME_LENGTH),
+            displayName.substring(0, MAX_NAME_LENGTH),
             avatarUrl,
             `https://matrix.to/#/${sender}`,
         );

--- a/src/matrixroomhandler.ts
+++ b/src/matrixroomhandler.ts
@@ -146,9 +146,9 @@ export class MatrixRoomHandler {
 
     // tslint:disable-next-line no-any
     public async OnAliasQuery(alias: string): Promise<any> {
-        const aliasLocalpart = alias.substr("#".length, alias.indexOf(":") - 1);
+        const aliasLocalpart = alias.substring("#".length, alias.indexOf(":") - 1);
         log.info("Got request for #", aliasLocalpart);
-        const srvChanPair = aliasLocalpart.substr("_discord_".length).split("_", ROOM_NAME_PARTS);
+        const srvChanPair = aliasLocalpart.substring("_discord_".length).split("_", ROOM_NAME_PARTS);
         if (srvChanPair.length < ROOM_NAME_PARTS || srvChanPair[0] === "" || srvChanPair[1] === "") {
             log.warn(`Alias '${aliasLocalpart}' was missing a server and/or a channel`);
             return;

--- a/src/matrixroomhandler.ts
+++ b/src/matrixroomhandler.ts
@@ -146,7 +146,7 @@ export class MatrixRoomHandler {
 
     // tslint:disable-next-line no-any
     public async OnAliasQuery(alias: string): Promise<any> {
-        const aliasLocalpart = alias.substring("#".length, alias.indexOf(":") - 1);
+        const aliasLocalpart = alias.substring("#".length, alias.indexOf(":"));
         log.info("Got request for #", aliasLocalpart);
         const srvChanPair = aliasLocalpart.substring("_discord_".length).split("_", ROOM_NAME_PARTS);
         if (srvChanPair.length < ROOM_NAME_PARTS || srvChanPair[0] === "" || srvChanPair[1] === "") {

--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -114,7 +114,7 @@ export class UserSyncroniser {
             log.info(`Creating new user ${userState.mxUserId}`);
             remoteUser = new RemoteUser(userState.id);
             await this.userStore.linkUsers(
-                userState.mxUserId.substr("@".length),
+                userState.mxUserId.substring("@".length),
                 userState.id,
             );
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -358,7 +358,7 @@ export class Util {
 
     public static ParseMxid(unescapedMxid: string, escape: boolean = true) {
         const RADIX = 16;
-        const parts = unescapedMxid.substr(1).split(":");
+        const parts = unescapedMxid.substring(1).split(":");
         const domain = parts[1];
         let localpart = parts[0];
         if (escape) {


### PR DESCRIPTION
`String.prototype.substr()` is not part of the standard JavaScript core. While browsers and NodeJS will likely not drop it, its use is discouraged.

In all places in this project where this is used, `String.prototype.substring()` does the same thing. That function is part of the core standard.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr (note the :-1: in the sidebar)
https://stackoverflow.com/questions/52640271/why-string-prototype-substr-seems-to-be-deprecated