### PR TITLE
Fix presence status error, fix client init

### DIFF
--- a/src/clientfactory.ts
+++ b/src/clientfactory.ts
@@ -69,7 +69,7 @@ export class DiscordClientFactory {
             fetchAllMembers: false,
             messageCacheLifetime: 5,
             ws: {
-                intents: this.config.usePrivilegedIntents ? Intents.ALL : Intents.NON_PRIVILEGED,
+                intents: Intents.NON_PRIVILEGED,
             },
         });
 
@@ -102,7 +102,7 @@ export class DiscordClientFactory {
             fetchAllMembers: false,
             messageCacheLifetime: 5,
             ws: {
-                intents: this.config.usePrivilegedIntents ? Intents.ALL : Intents.NON_PRIVILEGED,
+                intents: Intents.NON_PRIVILEGED,
             },
         });
 

--- a/src/clientfactory.ts
+++ b/src/clientfactory.ts
@@ -43,7 +43,7 @@ export class DiscordClientFactory {
             fetchAllMembers: this.config.usePrivilegedIntents,
             messageCacheLifetime: 5,
             ws: {
-                intents: this.config.usePrivilegedIntents ? Intents.PRIVILEGED : Intents.NON_PRIVILEGED,
+                intents: this.config.usePrivilegedIntents ? Intents.ALL : Intents.NON_PRIVILEGED,
             },
         });
 
@@ -69,7 +69,7 @@ export class DiscordClientFactory {
             fetchAllMembers: false,
             messageCacheLifetime: 5,
             ws: {
-                intents: Intents.NON_PRIVILEGED,
+                intents: this.config.usePrivilegedIntents ? Intents.ALL : Intents.NON_PRIVILEGED,
             },
         });
 
@@ -102,7 +102,7 @@ export class DiscordClientFactory {
             fetchAllMembers: false,
             messageCacheLifetime: 5,
             ws: {
-                intents: Intents.NON_PRIVILEGED,
+                intents: this.config.usePrivilegedIntents ? Intents.ALL : Intents.NON_PRIVILEGED,
             },
         });
 

--- a/src/presencehandler.ts
+++ b/src/presencehandler.ts
@@ -144,7 +144,7 @@ export class PresenceHandler {
         const intent = this.bot.GetIntentFromDiscordMember(user);
         try {
             await intent.ensureRegistered();
-            await intent.underlyingClient.setPresenceStatus(status.Presence, status.StatusMsg || '');
+            await intent.underlyingClient.setPresenceStatus(status.Presence, status.StatusMsg || "");
         } catch (ex) {
             if (ex.errcode !== "M_FORBIDDEN") {
                 log.warn(`Could not update Matrix presence for ${user.id}`);

--- a/src/presencehandler.ts
+++ b/src/presencehandler.ts
@@ -144,7 +144,7 @@ export class PresenceHandler {
         const intent = this.bot.GetIntentFromDiscordMember(user);
         try {
             await intent.ensureRegistered();
-            await intent.underlyingClient.setPresenceStatus(status.Presence, status.StatusMsg);
+            await intent.underlyingClient.setPresenceStatus(status.Presence, status.StatusMsg || '');
         } catch (ex) {
             if (ex.errcode !== "M_FORBIDDEN") {
                 log.warn(`Could not update Matrix presence for ${user.id}`);

--- a/test/test_clientfactory.ts
+++ b/test/test_clientfactory.ts
@@ -76,13 +76,13 @@ describe("ClientFactory", () => {
     describe("getDiscordId", () => {
         it("should fetch id successfully", async () => {
             const config = new DiscordBridgeConfigAuth();
-            const cf = new DiscordClientFactory(null);
+            const cf = new DiscordClientFactory(null, config);
             const discordId = await cf.getDiscordId("passme");
             expect(discordId).equals("12345");
         });
         it("should fail if the token is not recognised", async () => {
             const config = new DiscordBridgeConfigAuth();
-            const cf = new DiscordClientFactory(null);
+            const cf = new DiscordClientFactory(null, config);
             try {
                 await cf.getDiscordId("failme");
                 throw new Error("didn't fail");
@@ -102,7 +102,7 @@ describe("ClientFactory", () => {
         });
         it("should return cached client", async () => {
             const config = new DiscordBridgeConfigAuth();
-            const cf = new DiscordClientFactory(null);
+            const cf = new DiscordClientFactory(null, config);
             cf.clients.set("@user:localhost", "testclient");
             const client = await cf.getClient("@user:localhost");
             expect(client).equals("testclient");
@@ -116,14 +116,14 @@ describe("ClientFactory", () => {
         });
         it("should fetch user client if userid matches", async () => {
             const config = new DiscordBridgeConfigAuth();
-            const cf = new DiscordClientFactory(STORE);
+            const cf = new DiscordClientFactory(STORE, config);
             const client = await cf.getClient("@valid:localhost");
             expect(client).is.not.null;
             expect(cf.clients.has("@valid:localhost")).to.be.true;
         });
         it("should fail if the user client cannot log in", async () => {
             const config = new DiscordBridgeConfigAuth();
-            const cf = new DiscordClientFactory(STORE);
+            const cf = new DiscordClientFactory(STORE, config);
             cf.botClient = 1;
             const client = await cf.getClient("@invalid:localhost");
             expect(client).to.equal(cf.botClient);

--- a/test/test_presencehandler.ts
+++ b/test/test_presencehandler.ts
@@ -98,7 +98,7 @@ describe("PresenceHandler", () => {
             const member = new MockPresence(new MockUser("ghi", "alice"), "def", "online");
             await handler.ProcessUser(member as any);
             appservice.getIntentForSuffix(member.userID)
-                .underlyingClient.wasCalled("setPresenceStatus", true, "online", undefined);
+                .underlyingClient.wasCalled("setPresenceStatus", true, "online", "");
         });
         it("processes an offline user", async () => {
             lastStatus = null;
@@ -106,7 +106,7 @@ describe("PresenceHandler", () => {
             const member = new MockPresence(new MockUser("abc", "alice"), "def", "offline");
             await handler.ProcessUser(member as any);
             appservice.getIntentForSuffix(member.userID)
-                .underlyingClient.wasCalled("setPresenceStatus", true, "offline", undefined);
+                .underlyingClient.wasCalled("setPresenceStatus", true, "offline", "");
         });
         it("processes an idle user", async () => {
             lastStatus = null;
@@ -114,7 +114,7 @@ describe("PresenceHandler", () => {
             const member = new MockPresence(new MockUser("abc", "alice"), "def", "idle");
             await handler.ProcessUser(member as any);
             appservice.getIntentForSuffix(member.userID)
-                .underlyingClient.wasCalled("setPresenceStatus", true, "unavailable", undefined);
+                .underlyingClient.wasCalled("setPresenceStatus", true, "unavailable", "");
         });
         it("processes an dnd user", async () => {
             lastStatus = null;


### PR DESCRIPTION
I've been pinging you on the matrix channel.

The intent fixes are for when the `usePrivilegedIntents` is set to `true` in the config, and the client passed wrong flags so no channels, no messages, no nothing would come through the API. I, as a newcomer to this module and the discord API, worked on it a couple days until I managed to figured this out.

The status fix is for the presence updates, as `null` could be passed which the matrix api doesn't tolerate and gives an error in return. An empty string when `null` would be passed is accepted.