### PR TITLE
Fix typo with options.reg

### DIFF
--- a/tools/adminme.ts
+++ b/tools/adminme.ts
@@ -95,7 +95,7 @@ if (!options.userid) {
     process.exit(1);
 }
 
-const {appservice} = ToolsHelper.getToolDependencies(options.config, options.reg, false);
+const {appservice} = ToolsHelper.getToolDependencies(options.config, options.registration, false);
 
 async function run() {
     try {


### PR DESCRIPTION
The '-r' flag value is stored under the alias 'registration', but is later passed along to ToolsHelper.getToolDependencies() as 'options.reg' which is undefined. This causes the internal default of './discord-registration.yaml' to always be used, instead of what the user defined. Should be fixed by changing options.reg to options.registration.