### PR TITLE
Fixes issues with addRoomsToDirectory, adminme, chanfix, and ghostfix

### DIFF
--- a/tools/addRoomsToDirectory.ts
+++ b/tools/addRoomsToDirectory.ts
@@ -67,7 +67,7 @@ if (options.help) {
     process.exit(0);
 }
 
-const {store, appservice} = ToolsHelper.getToolDependencies(options.config, options.registration);
+const {store, appservice} = ToolsHelper.getToolDependencies(options.config, options.registration, true);
 
 async function run(): Promise<void> {
     try {

--- a/tools/adminme.ts
+++ b/tools/adminme.ts
@@ -95,7 +95,7 @@ if (!options.userid) {
     process.exit(1);
 }
 
-const {appservice} = ToolsHelper.getToolDependencies(options.config, options.reg, false);
+const {appservice} = ToolsHelper.getToolDependencies(options.config, options.registration, false);
 
 async function run() {
     try {

--- a/tools/chanfix.ts
+++ b/tools/chanfix.ts
@@ -67,7 +67,7 @@ if (options.help) {
 }
 
 async function run() {
-    const {store, appservice, config} = ToolsHelper.getToolDependencies(options.config);
+    const {store, appservice, config} = ToolsHelper.getToolDependencies(options.config, options.registration);
     await store!.init();
     const discordbot = new DiscordBot(config, appservice, store!);
     await discordbot.init();

--- a/tools/ghostfix.ts
+++ b/tools/ghostfix.ts
@@ -76,7 +76,7 @@ if (options.help) {
 }
 
 async function run() {
-    const {store, appservice, config} = ToolsHelper.getToolDependencies(options.config);
+    const {appservice, config, store} = ToolsHelper.getToolDependencies(options.config, options.registration);
     await store!.init();
     const discordbot = new DiscordBot(config, appservice, store!);
     await discordbot.init();

--- a/tools/toolshelper.ts
+++ b/tools/toolshelper.ts
@@ -28,7 +28,7 @@ export class ToolsHelper {
             registration: registration as IAppserviceRegistration,
         });
 
-        const store = needsStore ? new DiscordStore(config.database ? config.database.filename : "discord.db") : null;
+        const store = needsStore ? new DiscordStore(config.database) : null;
         return {
             appservice,
             config,


### PR DESCRIPTION
This applies #666 to all the tool scripts that use `reg` instead of `registration`. It also fixes the ternary in toolshelper so store points the `database` key instead of `database.filename`.