### PR TITLE
Metrics.enable: Correct config sample and schema

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -106,6 +106,6 @@ ghosts:
     usernamePattern: ":username#:tag"
 # Prometheus-compatible metrics endpoint
 metrics:
-    enabled: false
+    enable: false
     port: 9001
     host: "127.0.0.1"

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -127,7 +127,7 @@ properties:
     metrics:
         type: "object"
         properties:
-            enabled:
+            enable:
                 type: "boolean"
             port:
                 type: "number"

--- a/src/config.ts
+++ b/src/config.ts
@@ -158,7 +158,7 @@ class DiscordBridgeConfigGhosts {
 }
 
 export class DiscordBridgeConfigMetrics {
-    public enable: boolean;
+    public enable: boolean = false;
     public port: number = 9001;
     public host: string = "127.0.0.1";
 }


### PR DESCRIPTION
In #640 I mistakenly added the config flag as `enabled` instead of `enabled`.

Not that another flag for logging is already called `enabled`. It may be worth supporting both tenses.