### PR TITLE
Quote globs in npm scripts so globstars are expanded properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "A bridge between Matrix and Discord",
   "main": "discordas.js",
   "scripts": {
-    "test": "mocha -r ts-node/register test/config.ts test/test_*.ts test/**/test_*.ts",
-    "lint": "eslint -c .eslintrc --max-warnings 200 src/**/*.ts test/**/*.ts",
+    "test": "mocha -r ts-node/register test/config.ts 'test/**/test_*.ts'",
+    "lint": "eslint -c .eslintrc --max-warnings 200 'src/**/*.ts' 'test/**/*.ts'",
     "coverage": "tsc && nyc mocha build/test/config.js build/test",
     "build": "tsc",
     "postinstall": "npm run build",


### PR DESCRIPTION
https://medium.com/@jakubsynowiec/you-should-always-quote-your-globs-in-npm-scripts-621887a2a784

Without proper globstar handling, linting was only getting applied to files in subdirectories of `src` and `test`, not files directly inside `src` and `test`.