### PR TITLE
Add reply to feature-matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,14 @@ In a vague order of what is coming up next
      - [x] Audio/Video content
      - [ ] Typing notifs (**Not supported, requires syncing**)
      - [x] User Profiles
+     - [x] Reply
  - Discord -> Matrix
      - [x] Text content
      - [x] Image content
      - [x] Audio/Video content
      - [x] Typing notifs
      - [x] User Profiles
+     - [ ] Reply
      - [x] Presence
      - [x] Per-guild display names.
  - [x] Group messages


### PR DESCRIPTION
Both Martix and Discord have a reply function which basically quotes a message when replying to it.

When replying to a message from Discord inside of Matrix, the reply shows up inside Discord.

When replying to a message from Matrix inside of Discord, the reply does not show up inside Matrix.

Example:
![1Auswahl_895](https://user-images.githubusercontent.com/11144627/119414949-e3813200-bcf0-11eb-83a7-e374be289339.png)
![1Auswahl_896](https://user-images.githubusercontent.com/11144627/119414960-ea0fa980-bcf0-11eb-9729-e22347b364e5.png)
