### PR TITLE
Discord To Matrix inline replies

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1005,6 +1005,20 @@ export class DiscordBot {
                     formatted_body: result.formattedBody,
                     msgtype: result.msgtype,
                 };
+                if (msg.reference) {
+                    const storeEvent = await this.store.Get(DbEvent, {discord_id: msg.reference?.messageID})
+                    if (storeEvent && storeEvent.Result)
+                    {
+                        while(storeEvent.Next())
+                        {
+                            sendContent["m.relates_to"] = {
+                                "m.in_reply_to": {
+                                    event_id: storeEvent.MatrixId.split(";")[0]
+                                }
+                            };
+                        }
+                    }
+                }
                 if (editEventId) {
                     sendContent.body = `* ${result.body}`;
                     sendContent.formatted_body = `* ${result.formattedBody}`;


### PR DESCRIPTION
This should largely reduce confusion when people are talking over the bridge as the context often gets lost when people reference posts unrelated to current conversations.

End result: 
![image](https://user-images.githubusercontent.com/17257449/119498315-2af9d380-bd6e-11eb-9e2c-bf6c70e67465.png)

Edit: the previously mentioned PR is no longer necessary.

