### PR TITLE
Replace discordapp.com with discord.com

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,9 @@ build
 
 *.db
 *.db.backup
+
+.vscode/
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ should show up in the network list on Element and other clients.
 
 ### Setting up Discord
 
-* Create a new application via https://discordapp.com/developers/applications
+* Create a new application via https://discord.com/developers/applications
 * Make sure to create a bot user. Fill in ``config.yaml``
 * Run ``npm run addbot`` to get a authorisation link.
 * Give this link to owners of the guilds you plan to bridge.

--- a/src/matrixcommandhandler.ts
+++ b/src/matrixcommandhandler.ts
@@ -65,7 +65,7 @@ export class MatrixCommandHandler {
                     "4. In the matrix room, send the message `!discord bridge <guild id> <channel id>` " +
                     "(without the backticks)\n" +
                     "   Note: The Guild ID and Channel ID can be retrieved from the URL in your web browser.\n" +
-                    "   The URL is formatted as https://discordapp.com/channels/GUILD_ID/CHANNEL_ID\n" +
+                    "   The URL is formatted as https://discord.com/channels/GUILD_ID/CHANNEL_ID\n" +
                     "5. Enjoy your new bridge!",
                 /* eslint-enable prefer-template */
                 params: ["guildId", "channelId"],


### PR DESCRIPTION
* Replaces discordapp.com with discord.com
* Adds Visual Studio Code files to `.gitgnore` (based on [github/gitignore](https://github.com/github/gitignore/blob/master/Global/VisualStudioCode.gitignore))

Related to:
* https://github.com/Half-Shot/matrix-appservice-discord/issues/611