### PR TITLE
Fix some problems for unbridge actions

### DIFF
--- a/changelog.d/733.bugfix
+++ b/changelog.d/733.bugfix
@@ -1,0 +1,1 @@
+Fix some problems for unbridge actions.

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -76,26 +76,26 @@ database:
   filename: "discord.db"
   # connString: "postgresql://user:password@localhost/database_name"
 room:
-  # Set the default visibility of alias rooms, defaults to "public".
+  # Set the default visibility of portal rooms in the room directory, defaults to "public".
   # One of: "public", "private"
   defaultVisibility: "public"
 channel:
     # Pattern of the name given to bridged rooms.
     # Can use :guild for the guild name and :name for the channel name.
     namePattern: "[Discord] :guild :name"
-    # Changes made to rooms when a channel is deleted.
+    # Changes made to rooms when a channel is deleted or a room is unbridged.
     deleteOptions:
        # Prefix the room name with a string.
        #namePrefix: "[Deleted]"
        # Prefix the room topic with a string.
        #topicPrefix: "This room has been deleted"
-       # Disable people from talking in the room by raising the event PL to 50
+       # Disable people from talking in the room by raising the event PL to 50. For portal rooms only.
        disableMessaging: false
-       # Remove the discord alias from the room.
+       # Remove the discord alias from the room. For portal rooms only.
        unsetRoomAlias: true
-       # Remove the room from the directory.
+       # Remove the room from the directory. For portal rooms only.
        unlistFromDirectory: true
-       # Set the room to be unavailable for joining without an invite.
+       # Set the room to be unavaliable for joining without an invite. For portal rooms only.
        setInviteOnly: true
        # Make all the discord users leave the room.
        ghostsLeave: true

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -709,7 +709,7 @@ export class DiscordBot {
         }
 
         if (entries.length === 0) {
-            log.verbose(`Couldn"t find channel for roomId ${roomId}.`);
+            log.verbose(`Couldn't find channel for roomId ${roomId}.`);
             throw Error("Room(s) not found.");
         }
         const entry = entries[0];
@@ -801,7 +801,7 @@ export class DiscordBot {
         try {
             channel = await this.GetChannelFromRoomId(roomId, client);
         } catch (ex) {
-            log.error("Failed to get channel for ", roomId, ex);
+            log.warn(`Failed to get channel for ${roomId}, so it must not have been bridged`);
             return;
         }
         if (channel.type !== "text") {

--- a/src/channelsyncroniser.ts
+++ b/src/channelsyncroniser.ts
@@ -353,7 +353,7 @@ export class ChannelSyncroniser {
             for (const member of channel.members.array()) {
                 try {
                     const mIntent = this.bot.GetIntentFromDiscordMember(member);
-                    await client.leaveRoom(roomId);
+                    await mIntent.leaveRoom(roomId);
                     log.verbose(`${member.id} left ${roomId}.`);
                 } catch (e) {
                     log.warn(`Failed to make ${member.id} leave `);
@@ -389,7 +389,7 @@ export class ChannelSyncroniser {
             }
         }
 
-        if (plumbed !== true) {
+        if (!plumbed) {
             if (options.unsetRoomAlias) {
                 try {
                     const alias = `#_${entry.remote!.roomId}:${this.config.bridge.domain}`;
@@ -422,7 +422,7 @@ export class ChannelSyncroniser {
                         roomId,
                         "m.room.join_rules",
                         "",
-                        {join_role: "invite"},
+                        {join_rule: "invite"},
                     );
                 } catch (e) {
                     log.error(`Couldn't set ${roomId} to private ${e}`);


### PR DESCRIPTION
Partially fixes #538 and #719.

It's still possible for ghost users not to leave because the discord.js backend doesn't know they exist. It seems that restarting the bridge makes the backend forget about Discord users until the next time they send a message.