### PR TITLE
When creating a portal room, update cache of rooms bot is in

### DIFF
--- a/changelog.d/734.bugfix
+++ b/changelog.d/734.bugfix
@@ -1,0 +1,1 @@
+When creating a portal room, immediately update cache of rooms bot is in.

--- a/src/discordas.ts
+++ b/src/discordas.ts
@@ -198,6 +198,7 @@ async function run(): Promise<void> {
             try {
                 const createRoomOpts = await roomhandler.OnAliasQuery(roomAlias);
                 await createRoom(createRoomOpts);
+                eventProcessor.OnCreate(createRoomOpts.__roomId);
                 await roomhandler.OnAliasQueried(roomAlias, createRoomOpts.__roomId);
             } catch (err) {
                 log.error("Exception thrown while handling \"query.room\" event", err);

--- a/src/matrixcommandhandler.ts
+++ b/src/matrixcommandhandler.ts
@@ -47,6 +47,10 @@ export class MatrixCommandHandler {
         this.botJoinedRooms.add(event.room_id);
     }
 
+    public HandleCreate(roomId: string) {
+        this.botJoinedRooms.add(roomId);
+    }
+
     public async Process(event: IMatrixEvent, roomEntry: IRoomStoreEntry|null) {
         if (!(await this.isBotInRoom(event.room_id))) {
             log.warn(`Bot is not in ${event.room_id}. Ignoring command`);

--- a/src/matrixeventprocessor.ts
+++ b/src/matrixeventprocessor.ts
@@ -82,6 +82,10 @@ export class MatrixEventProcessor {
         }
     }
 
+    public OnCreate(roomId: string) {
+        this.mxCommandHandler.HandleCreate(roomId)
+    }
+
     /**
      * Callback which is called when the HS notifies the bridge of a new event.
      *


### PR DESCRIPTION
Otherwise, bot may not react to `!discord` commands in a portal room until some time passes.

There might be a better way of doing this, though.