### PR TITLE
Handle invalid Discord tokens gracefully

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -38,6 +38,8 @@ bridge:
   disableInviteNotifications: false
   # Auto-determine the language of code blocks (this can be CPU-intensive)
   determineCodeLanguage: false
+  # MXID of an admin user that will be PMd if the bridge experiences problems. Optional
+  adminMxid: '@admin:localhost'
 # Authentication configuration for the discord bot.
 auth:
   # This MUST be a string (wrapped in quotes)

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -40,6 +40,8 @@ bridge:
   determineCodeLanguage: false
   # MXID of an admin user that will be PMd if the bridge experiences problems. Optional
   adminMxid: '@admin:localhost'
+  # The message to send to the bridge admin if the Discord token is not valid
+  invalidTokenMessage: 'Your Discord bot token seems to be invalid, and the bridge cannot function. Please update it in your bridge settings and restart the bridge'
 # Authentication configuration for the discord bot.
 auth:
   # This MUST be a string (wrapped in quotes)

--- a/src/config.ts
+++ b/src/config.ts
@@ -100,6 +100,7 @@ class DiscordBridgeConfigBridge {
     public determineCodeLanguage: boolean = false;
     public activityTracker: UserActivityTrackerConfig = UserActivityTrackerConfig.DEFAULT;
     public userLimit: number|null = null;
+    public adminMxid: string|null = null;
 }
 
 export class DiscordBridgeConfigDatabase {

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,6 +101,7 @@ class DiscordBridgeConfigBridge {
     public activityTracker: UserActivityTrackerConfig = UserActivityTrackerConfig.DEFAULT;
     public userLimit: number|null = null;
     public adminMxid: string|null = null;
+    public invalidTokenMessage: string = 'Your Discord token is invalid';
 }
 
 export class DiscordBridgeConfigDatabase {

--- a/src/discordas.ts
+++ b/src/discordas.ts
@@ -271,9 +271,9 @@ async function notifyBridgeAdmin(client: MatrixClient, adminMxid: string, messag
 let adminNotified = false;
 
 async function startDiscordBot(
-    discordbot:    DiscordBot,
-    client:        MatrixClient,
-    config:        DiscordBridgeConfig,
+    discordbot: DiscordBot,
+    client: MatrixClient,
+    config: DiscordBridgeConfig,
     falloffSeconds = 5
 ) {
     const adminMxid = config.bridge.adminMxid;


### PR DESCRIPTION
732be16490814a28ec8e46d441e9498912413bd8 ensures we don't crash on startup, and thus not crashloop if the token has been regenerated or configured incorrectly.

09a36313d186379c32a26079b5c2cfea6f1ccaf9 proposes a way to notify a bridge admin (optional, configurable) about the startup problems.