### PR TITLE
Dockerfile build fails: move to python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:14-alpine AS BUILD
 COPY . /tmp/src
 # install some dependencies needed for the build process
-RUN apk add --no-cache -t build-deps make gcc g++ python ca-certificates libc-dev wget git
+RUN apk add --no-cache -t build-deps make gcc g++ py-pip ca-certificates libc-dev wget git
 RUN cd /tmp/src \
     && yarn
 


### PR DESCRIPTION
As python 2 [was deprecated](https://www.python.org/doc/sunset-python-2/) quite some time ago and the package `python` removed from the alpine linux package registries, I suggest changing this to `py-pip`