### PR TITLE
fix: precaching of all transactions causes errors

### DIFF
--- a/src/store.ts
+++ b/src/store.ts
@@ -295,7 +295,7 @@ export class DiscordStore implements IAppserviceStorageProvider {
         if(registered !== undefined) {
             return registered;
         }
-        const row = await this.db.Get("SELECT FROM registered_users WHERE user_id = $userId;", {userId})
+        const row = await this.db.Get("SELECT user_id FROM registered_users WHERE user_id = $userId;", {userId})
             .catch((err) => {
                 log.warn("Failed to get registered user", err);
             });
@@ -319,7 +319,7 @@ export class DiscordStore implements IAppserviceStorageProvider {
         if(completed !== undefined) {
             return completed;
         }
-        const row = await this.db.Get("SELECT FROM as_txns WHERE txn_id = $transactionId;", {transactionId})
+        const row = await this.db.Get("SELECT txn_id FROM as_txns WHERE txn_id = $transactionId;", {transactionId})
             .catch((err) => {
                 log.warn("Failed to get registered user", err);
             });

--- a/src/store.ts
+++ b/src/store.ts
@@ -276,8 +276,8 @@ export class DiscordStore implements IAppserviceStorageProvider {
         await data.Delete(this);
     }
 
-    public addRegisteredUser(userId: string) {
-        this.db.Run("INSERT INTO registered_users VALUES ($userId)", {userId})
+    public async addRegisteredUser(userId: string): Promise<unknown> {
+        return this.db.Run("INSERT INTO registered_users VALUES ($userId)", {userId})
             .then(() => this.registeredUsers.set(userId, true))
             .catch((err) => {
                 log.warn("Failed to insert registered user", err);
@@ -298,8 +298,8 @@ export class DiscordStore implements IAppserviceStorageProvider {
         return registered;
     }
 
-    public setTransactionCompleted(transactionId: string) {
-        this.db.Run("INSERT INTO as_txns (txn_id) VALUES ($transactionId)", {transactionId})
+    public async setTransactionCompleted(transactionId: string): Promise<unknown> {
+        return this.db.Run("INSERT INTO as_txns (txn_id) VALUES ($transactionId)", {transactionId})
             .then(() => this.asTxns.set(transactionId, true))
             .catch((err) => {
                 log.warn("Failed to insert txn", err);

--- a/src/store.ts
+++ b/src/store.ts
@@ -43,8 +43,8 @@ export class DiscordStore implements IAppserviceStorageProvider {
     private pRoomStore: DbRoomStore;
     private pUserStore: DbUserStore;
 
-    private registeredUsersCache: TimedCache<string, boolean>; // value = is registered
-    private txnsCompletionStatusCache: TimedCache<string, boolean>; // value = is transaction completed
+    private registeredUsersCache: TimedCache<string, boolean>;
+    private txnsCompletionStatusCache: TimedCache<string, boolean>;
 
     constructor(configOrFile: DiscordBridgeConfigDatabase|string) {
         if (typeof(configOrFile) === "string") {

--- a/src/store.ts
+++ b/src/store.ts
@@ -306,7 +306,7 @@ export class DiscordStore implements IAppserviceStorageProvider {
             .catch((err) => {
                 log.warn("Failed to get registered user", err);
             });
-        // user in db = registered
+
         registered = row != null && row.user_id === userId;
         this.registeredUsersCache.set(userId, registered);
         log.verbose(`User registration status added to registeredUsersCache. 
@@ -337,9 +337,9 @@ export class DiscordStore implements IAppserviceStorageProvider {
         }
         const row = await this.db.Get("SELECT txn_id FROM as_txns WHERE txn_id = $transactionId;", {transactionId})
             .catch((err) => {
-                log.warn("Failed to get registered user", err);
+                log.warn("Failed to get txn", err);
             });
-        // tx in db = completed
+
         completed = row != null && row.txn_id === transactionId;
         this.txnsCompletionStatusCache.set(transactionId, completed);
         log.verbose(`Txn completion status added to txnsCompletionStatusCache. 

--- a/src/store.ts
+++ b/src/store.ts
@@ -299,6 +299,7 @@ export class DiscordStore implements IAppserviceStorageProvider {
             .catch((err) => {
                 log.warn("Failed to get registered user", err);
             });
+        // user in db = registered
         registered = row != null && row.user_id === userId;
         this.registeredUsersCache.set(userId, registered);
         return registered;
@@ -322,6 +323,7 @@ export class DiscordStore implements IAppserviceStorageProvider {
             .catch((err) => {
                 log.warn("Failed to get registered user", err);
             });
+        // tx in db = completed
         completed = row != null && row.txn_id === transactionId;
         this.asTxnsCache.set(transactionId, completed);
         return completed;

--- a/src/store.ts
+++ b/src/store.ts
@@ -45,6 +45,7 @@ export class DiscordStore implements IAppserviceStorageProvider {
 
     private registeredUsersCache: TimedCache<string, boolean>;
     private txnsCompletionStatusCache: TimedCache<string, boolean>;
+    private cacheCleanupIntervalHandle: NodeJS.Timeout;
 
     constructor(configOrFile: DiscordBridgeConfigDatabase|string) {
         if (typeof(configOrFile) === "string") {
@@ -133,13 +134,14 @@ export class DiscordStore implements IAppserviceStorageProvider {
         }
         log.info("Updated database to the latest schema");
 
-        setInterval(() => {
+        this.cacheCleanupIntervalHandle = setInterval(() => {
             this.txnsCompletionStatusCache.cleanUp();
             this.registeredUsersCache.cleanUp();
         }, CACHE_CLEANUP_MILLIS);
     }
 
     public async close() {
+        clearInterval(this.cacheCleanupIntervalHandle);
         await this.db.Close();
     }
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -29,8 +29,8 @@ import { UserActivitySet, UserActivity } from "matrix-appservice-bridge";
 import {TimedCache} from "./structures/timedcache";
 const log = new Log("DiscordStore");
 
-const REGISTERED_USERS_CACHE_LIFETIME_MILLIS = 15 * 60 * 1000; // 15 minutes
-const TX_IDS_CACHE_LIFETIME_MILLIS = 15 * 60 * 1000; // 15 minutes
+const REGISTERED_USERS_CACHE_LIFETIME_MILLIS = 60 * 60 * 1000; // 60 minutes
+const TX_IDS_CACHE_LIFETIME_MILLIS = 10 * 60 * 1000; // 10 minutes
 const CACHE_CLEANUP_MILLIS = 30 * 1000; // 30 seconds
 
 export const CURRENT_SCHEMA = 12;

--- a/src/store.ts
+++ b/src/store.ts
@@ -31,6 +31,7 @@ const log = new Log("DiscordStore");
 
 const REGISTERED_USERS_CACHE_LIFETIME_MILLIS = 15 * 60 * 1000; // 15 minutes
 const TX_IDS_CACHE_LIFETIME_MILLIS = 15 * 60 * 1000; // 15 minutes
+const CACHE_CLEANUP_MILLIS = 30 * 1000; // 30 seconds
 
 export const CURRENT_SCHEMA = 12;
 /**
@@ -131,6 +132,11 @@ export class DiscordStore implements IAppserviceStorageProvider {
             await this.setSchemaVersion(version);
         }
         log.info("Updated database to the latest schema");
+
+        setInterval(() => {
+            this.asTxns.cleanUp();
+            this.registeredUsers.cleanUp();
+        }, CACHE_CLEANUP_MILLIS);
     }
 
     public async close() {

--- a/src/store.ts
+++ b/src/store.ts
@@ -287,7 +287,7 @@ export class DiscordStore implements IAppserviceStorageProvider {
     public async isUserRegistered(userId: string): Promise<boolean> {
         let registered = this.registeredUsers.get(userId);
         if(registered !== undefined) {
-            return Promise.resolve(registered);
+            return registered;
         }
         const row = await this.db.Get("SELECT FROM registered_users WHERE user_id = $userId;", {userId})
             .catch((err) => {
@@ -310,7 +310,7 @@ export class DiscordStore implements IAppserviceStorageProvider {
         // If txId exists in cache return with status
         let completed = this.asTxns.get(transactionId);
         if(completed !== undefined) {
-            return Promise.resolve(completed);
+            return completed;
         }
         const row = await this.db.Get("SELECT FROM as_txns WHERE txn_id = $transactionId;", {transactionId})
             .catch((err) => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -53,8 +53,8 @@ export class DiscordStore implements IAppserviceStorageProvider {
         } else {
             this.config = configOrFile;
         }
-        this.registeredUsersCache = new TimedCache<string, boolean>(REGISTERED_USERS_CACHE_LIFETIME_MILLIS);
-        this.txnsCompletionStatusCache = new TimedCache<string, boolean>(TX_IDS_CACHE_LIFETIME_MILLIS);
+        this.registeredUsersCache = new TimedCache<string, boolean>(REGISTERED_USERS_CACHE_LIFETIME_MILLIS, "registeredUsersCache");
+        this.txnsCompletionStatusCache = new TimedCache<string, boolean>(TX_IDS_CACHE_LIFETIME_MILLIS, "txnsCompletionStatusCache");
     }
 
     get roomStore() {

--- a/src/structures/timedcache.ts
+++ b/src/structures/timedcache.ts
@@ -7,7 +7,7 @@ interface ITimedValue<V> {
 }
 
 export class TimedCache<K, V> implements Map<K, V> {
-    private readonly  map: Map<K, ITimedValue<V>>;
+    private readonly map: Map<K, ITimedValue<V>>;
 
     public constructor(private readonly liveFor: number) {
         this.map = new Map();
@@ -15,6 +15,17 @@ export class TimedCache<K, V> implements Map<K, V> {
 
     public clear(): void {
         this.map.clear();
+    }
+
+    /**
+     * Removes invalid elements from a cache
+     */
+    public cleanUp(): void {
+        for (const [key, value] of this.map) {
+            if(this.filterV(value) === undefined) {
+                this.map.delete(key);
+            }
+        }
     }
 
     public delete(key: K): boolean {

--- a/src/structures/timedcache.ts
+++ b/src/structures/timedcache.ts
@@ -7,9 +7,13 @@ interface ITimedValue<V> {
 }
 
 export class TimedCache<K, V> implements Map<K, V> {
+    private static unnamedCacheNameCounter: number = 0;
     private readonly map: Map<K, ITimedValue<V>>;
 
-    public constructor(private readonly liveFor: number) {
+    public constructor(
+        private readonly liveFor: number,
+        private readonly cacheName: string|null = TimedCache.generateUnnamedCacheName()
+    ) {
         this.map = new Map();
     }
 
@@ -24,6 +28,7 @@ export class TimedCache<K, V> implements Map<K, V> {
         for (const [key, value] of this.map) {
             if(this.filterV(value) === undefined) {
                 this.map.delete(key);
+                log.silly(`removed entry with key='${key}' from cache '${this.cacheName}'`);
             }
         }
     }
@@ -113,6 +118,12 @@ export class TimedCache<K, V> implements Map<K, V> {
 
     get [Symbol.toStringTag](): "Map" {
         return "Map";
+    }
+
+    private static generateUnnamedCacheName(): string {
+        const cacheName = `unnamed-cache-${TimedCache.unnamedCacheNameCounter}`;
+        TimedCache.unnamedCacheNameCounter += 1;
+        return cacheName;
     }
 
     private filterV(v: ITimedValue<V>): V|undefined {

--- a/test/db/test_roomstore.ts
+++ b/test/db/test_roomstore.ts
@@ -17,6 +17,7 @@ limitations under the License.
 import { expect } from "chai";
 import { DiscordStore } from "../../src/store";
 import { RemoteStoreRoom, MatrixStoreRoom } from "../../src/db/roomstore";
+import {afterEach} from "mocha";
 
 // we are a test file and thus need those
 /* tslint:disable: no-any no-unused-expression */
@@ -27,6 +28,9 @@ describe("RoomStore", () => {
         store = new DiscordStore(":memory:");
         await store.init();
     });
+    afterEach(async () => {
+        await store.close();
+    })
     describe("upsertEntry|getEntriesByMatrixId", () => {
         it("will create a new entry", async () => {
             await store.roomStore.upsertEntry({

--- a/test/test_store.ts
+++ b/test/test_store.ts
@@ -27,6 +27,7 @@ describe("DiscordStore", () => {
         it("can create a db", async () => {
             const store = new DiscordStore(":memory:");
             await store.init();
+            await store.close();
         });
     });
     describe("addUserToken", () => {
@@ -34,6 +35,7 @@ describe("DiscordStore", () => {
             const store = new DiscordStore(":memory:");
             await store.init();
             await store.addUserToken("userid", "token", "discordid");
+            await store.close();
         });
     });
     describe("Get|Insert|Update<DbEmoji>", () => {
@@ -46,6 +48,7 @@ describe("DiscordStore", () => {
             emoji.Name = "TestEmoji";
             emoji.MxcUrl = "TestUrl";
             await store.Insert(emoji);
+            await store.close();
         });
         it("should get successfully", async () => {
             const store = new DiscordStore(":memory:");
@@ -59,12 +62,14 @@ describe("DiscordStore", () => {
             const getEmoji = await store.Get(DbEmoji, {emoji_id: "123"});
             expect(getEmoji!.Name).to.equal("TestEmoji");
             expect(getEmoji!.MxcUrl).to.equal("TestUrl");
+            await store.close();
         });
         it("should not return nonexistant emoji", async () => {
             const store = new DiscordStore(":memory:");
             await store.init();
             const getEmoji = await store.Get(DbEmoji, {emoji_id: "123"});
             expect(getEmoji!.Result).to.be.false;
+            await store.close();
         });
         it("should update successfully", async () => {
             const store = new DiscordStore(":memory:");
@@ -84,6 +89,7 @@ describe("DiscordStore", () => {
             expect(getEmoji!.Name).to.equal("TestEmoji2");
             expect(getEmoji!.MxcUrl).to.equal("NewURL");
             expect(getEmoji!.CreatedAt).to.not.equal(getEmoji!.UpdatedAt);
+            await store.close();
         });
     });
     describe("Get|Insert|Delete<DbEvent>", () => {
@@ -96,6 +102,7 @@ describe("DiscordStore", () => {
             event.GuildId = "123";
             event.ChannelId = "123";
             await store.Insert(event);
+            await store.close();
         });
         it("should get successfully", async () => {
             const store = new DiscordStore(":memory:");
@@ -118,6 +125,7 @@ describe("DiscordStore", () => {
             expect(getEventMatrix!.DiscordId).to.equal("456");
             expect(getEventMatrix!.GuildId).to.equal("123");
             expect(getEventMatrix!.ChannelId).to.equal("123");
+            await store.close();
         });
         const MSG_COUNT = 5;
         it("should get multiple discord msgs successfully", async () => {
@@ -133,6 +141,7 @@ describe("DiscordStore", () => {
             }
             const getEventDiscord = await store.Get(DbEvent, {matrix_id: "123"});
             expect(getEventDiscord!.ResultCount).to.equal(MSG_COUNT);
+            await store.close();
         });
         it("should get multiple matrix msgs successfully", async () => {
             const store = new DiscordStore(":memory:");
@@ -147,12 +156,14 @@ describe("DiscordStore", () => {
             }
             const getEventMatrix = await store.Get(DbEvent, {discord_id: "456"});
             expect(getEventMatrix!.ResultCount).to.equal(MSG_COUNT);
+            await store.close();
         });
         it("should not return nonexistant event", async () => {
             const store = new DiscordStore(":memory:");
             await store.init();
             const getMessage = await store.Get(DbEvent, {matrix_id: "123"});
             expect(getMessage!.Result).to.be.false;
+            await store.close();
         });
         it("should delete successfully", async () => {
             const store = new DiscordStore(":memory:");
@@ -167,6 +178,7 @@ describe("DiscordStore", () => {
             const getEvent = await store.Get(DbEvent, {matrix_id: "123"});
             getEvent!.Next();
             expect(getEvent!.Result).to.be.false;
+            await store.close();
         });
     });
 });

--- a/tools/addRoomsToDirectory.ts
+++ b/tools/addRoomsToDirectory.ts
@@ -99,6 +99,7 @@ async function run(): Promise<void> {
     } catch (e) {
         log.error(`Failed to run script`, e);
     }
+    await store?.close();
 }
 
 run(); // tslint:disable-line no-floating-promises


### PR DESCRIPTION
This PR changes the storage implementation to only load users and transaction ids when they are needed. Recent queries for txIds and users are cached. This fix also reduces memory consumption.

Fixes #765 