### PR TITLE
package.json: replace defunct git:// URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/Half-Shot/matrix-appservice-discord#readme",
   "dependencies": {
-    "better-discord.js": "git://github.com/Sorunome/better-discord.js.git#b5a28499899fe2d9e6aa1aa3b3c5d693ae672117",
+    "better-discord.js": "git+https://github.com/Sorunome/better-discord.js.git#b5a28499899fe2d9e6aa1aa3b3c5d693ae672117",
     "better-sqlite3": "^7.1.0",
     "command-line-args": "^5.1.1",
     "command-line-usage": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -814,9 +814,9 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-"better-discord.js@git://github.com/Sorunome/better-discord.js.git#b5a28499899fe2d9e6aa1aa3b3c5d693ae672117":
+"better-discord.js@git+https://github.com/Sorunome/better-discord.js.git#b5a28499899fe2d9e6aa1aa3b3c5d693ae672117":
   version "12.3.1"
-  resolved "git://github.com/Sorunome/better-discord.js.git#b5a28499899fe2d9e6aa1aa3b3c5d693ae672117"
+  resolved "git+https://github.com/Sorunome/better-discord.js.git#b5a28499899fe2d9e6aa1aa3b3c5d693ae672117"
   dependencies:
     "@discordjs/collection" "^0.1.6"
     "@discordjs/form-data" "^3.0.1"


### PR DESCRIPTION
Using Git over HTTPS instead.

Unencrypted `git://` does not seem to be supported by GitHub anymore:
https://github.blog/2021-09-01-improving-git-protocol-security-github/

This prevented the package from building on NixOS:
https://github.com/NixOS/nixpkgs/issues/165246