### PR TITLE
Force Discord avatars to be PNGs in a friendly matter

### DIFF
--- a/src/matrixeventprocessor.ts
+++ b/src/matrixeventprocessor.ts
@@ -499,13 +499,13 @@ export class MatrixEventProcessor {
             if (userOrMember instanceof Discord.User) {
                 embed.setAuthor(
                     userOrMember.username,
-                    userOrMember.avatarURL() || undefined,
+                    userOrMember.avatarURL({ format: 'png' }) || undefined,
                 );
                 return;
             } else if (userOrMember instanceof Discord.GuildMember) {
                 embed.setAuthor(
                     userOrMember.displayName,
-                    userOrMember.user.avatarURL() || undefined,
+                    userOrMember.user.avatarURL({ format: 'png' }) || undefined,
                 );
                 return;
             }

--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -257,7 +257,7 @@ export class UserSyncroniser {
             userState.createUser = true;
             userState.displayName = displayName;
             if (discordUser.avatar) {
-                userState.avatarUrl = discordUser.avatarURL();
+                userState.avatarUrl = discordUser.avatarURL({ format: 'png' });
                 userState.avatarId = discordUser.avatar;
             }
             return userState;
@@ -270,10 +270,12 @@ export class UserSyncroniser {
         }
 
         const oldAvatarUrl = remoteUser.avatarurl;
-        if (oldAvatarUrl !== discordUser.avatarURL()) {
+        const pngAvatarUrl = discordUser.avatarURL({ format: 'png' });
+        const webpAvatarUrl = discordUser.avatarURL();
+        if (oldAvatarUrl !== webpAvatarUrl && oldAvatarUrl !== pngAvatarUrl) {
             log.verbose(`User ${discordUser.id} avatarurl should be updated`);
             if (discordUser.avatar) {
-                userState.avatarUrl = discordUser.avatarURL();
+                userState.avatarUrl = pngAvatarUrl;
                 userState.avatarId = discordUser.avatar;
             } else {
                 userState.removeAvatar = true;


### PR DESCRIPTION
This can be considered a hack in order to fix #788 

It was discussed a bit in `#help:t2bot.io` on what the root cause of the issue might be, and it was found out that the bridge creates webp thumbnails for users on t2bot.io, which then often (not always for some reason) aren't mirrored to matrix.org (and potentially other HS), causing Clients to just display a default/broken avatar.

This PR circumvents the root cause, by just forcing all avatars to be in PNG format, as then thumbnails get mirrored correctly.
Only users who *update* their avatar will create revalidation. This is done in order to not revalidate *every user currently existing on the bridge* which would cause *quite* a bit of network traffic.


An alternative solution would be to implement #743; have a config file with a wished image file format, which is then used for checking the discord profile picture. I however am not that proficient with JS nor can I self-host/test my changes, hence this primitive solution.
Even better would be to figure out why the thumbnails aren't generates/mirrored in the first place. Possibly is related to #770, but not sure.

Either way, I'm opening this PR so that people who are self-hosting and are encountering the issue have a solution they can apply until the underlying root causes can be found and properly fixed.