### PR TITLE
update `python` to `python3`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:14-alpine AS BUILD
 COPY . /tmp/src
 # install some dependencies needed for the build process
-RUN apk add --no-cache -t build-deps make gcc g++ python ca-certificates libc-dev wget git
+RUN apk add --no-cache -t build-deps make gcc g++ python3 ca-certificates libc-dev wget git
 RUN cd /tmp/src \
     && yarn
 

--- a/changelog.d/798.docker
+++ b/changelog.d/798.docker
@@ -1,1 +1,1 @@
-Update Dockerfile to allow building for ARM arches.
+Update Dockerfile to specifically use Python 3.

--- a/changelog.d/798.docker
+++ b/changelog.d/798.docker
@@ -1,0 +1,1 @@
+Update Dockerfile to allow building for ARM arches.


### PR DESCRIPTION
This should allow building Docker images for ARM, since the `python` package only exists for x86.