### PR TITLE
Drop support for Node 12, default to Node 16

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: 18
+        node-version: 16
     - run: yarn
     - run: yarn lint
   test:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,14 +10,14 @@ jobs:
     - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: 14
+        node-version: 18
     - run: yarn
     - run: yarn lint
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [12, 14, 16]
+        node_version: [14, 16, 18]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node_version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:14-alpine AS BUILD
+FROM node:18-alpine AS BUILD
 COPY . /tmp/src
 # install some dependencies needed for the build process
 RUN apk add --no-cache -t build-deps make gcc g++ python ca-certificates libc-dev wget git
 RUN cd /tmp/src \
     && yarn
 
-FROM node:14-alpine
+FROM node:18-alpine
 ENV NODE_ENV=production
 COPY --from=BUILD /tmp/src/build /build
 COPY --from=BUILD /tmp/src/config /config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM node:18-alpine AS BUILD
+FROM node:16-alpine AS BUILD
 COPY . /tmp/src
 # install some dependencies needed for the build process
 RUN apk add --no-cache -t build-deps make gcc g++ python ca-certificates libc-dev wget git
 RUN cd /tmp/src \
     && yarn
 
-FROM node:18-alpine
+FROM node:16-alpine
 ENV NODE_ENV=production
 COPY --from=BUILD /tmp/src/build /build
 COPY --from=BUILD /tmp/src/config /config

--- a/changelog.d/811.removal
+++ b/changelog.d/811.removal
@@ -1,0 +1,1 @@
+Node.JS 12 is now unsupported, please upgrade to Node.JS 14 or later. Node.JS 16 becomes the new default version.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "discordas.js",
   "engines": {
     "npm": "please-use-yarn",
-    "node": "12.x - 16.x"
+    "node": "14.x - 18.x"
   },
   "scripts": {
     "test": "mocha -r ts-node/register test/config.ts test/test_*.ts test/**/test_*.ts",
@@ -69,7 +69,7 @@
     "@types/marked": "^1.1.0",
     "@types/mime": "^2.0.2",
     "@types/mocha": "^7.0.2",
-    "@types/node": "^12",
+    "@types/node": "^14",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
     "chai": "^4.2.0",


### PR DESCRIPTION
Like our other matrix.org bridges, we are dropping support for Node 12. Node 12 is out of support, and should not be used https://nodejs.org/en/about/releases/

Node 18 is new and fresh, and we should support it.

Node 16 will become our new default as the current latest LTS.