### PR TITLE
Add workflow to build container image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,44 @@
+name: Container Image
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  IMAGE_NAME: ${{ github.repository }}
+  REGISTRY: ghcr.io
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,10 +34,12 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
+          flavor: |
+            latest=true
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Container Image
 
 on:
   push:
-    branches: [ main ]
+    branches: [ develop ]
     tags: [ 'v*' ]
   pull_request:
-    branches: [ main ]
+    branches: [ develop ]
 
 env:
   IMAGE_NAME: ${{ github.repository }}
@@ -34,8 +34,6 @@ jobs:
         id: meta
         uses: docker/metadata-action@v3
         with:
-          flavor: |
-            latest=true
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image

--- a/changelog.d/826.misc
+++ b/changelog.d/826.misc
@@ -1,0 +1,1 @@
+Add workflow for building docker images, and push new docker images to ghcr.io.


### PR DESCRIPTION
Partial fix for #822 

The docker image build process used to be handled by dockerhub, but a while back they stopped doing builds for free (I believe?) and we never really fixed the issue.

Rather than going through the hoops to fix dockerhub, for the next release we can just direct users to use `ghcr.io/matrix-org/matrix-appservice-discord`.