### PR TITLE
Use debian slim for docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM node:16-alpine AS BUILD
+FROM node:16-slim AS BUILD
 COPY . /tmp/src
 # install some dependencies needed for the build process
-RUN apk add --no-cache -t build-deps make gcc g++ python3 ca-certificates libc-dev wget git
+RUN apt update && apt install -y build-essential make gcc g++ python3 ca-certificates libc-dev wget git
 
 # Workaround for https://github.com/matrix-org/matrix-appservice-discord/issues/803
 RUN git config --global url.https://github.com/.insteadOf git://github.com/
@@ -9,7 +9,7 @@ RUN git config --global url.https://github.com/.insteadOf git://github.com/
 RUN cd /tmp/src \
     && yarn
 
-FROM node:16-alpine
+FROM node:16-slim
 ENV NODE_ENV=production
 COPY --from=BUILD /tmp/src/build /build
 COPY --from=BUILD /tmp/src/config /config

--- a/changelog.d/828.bugfix
+++ b/changelog.d/828.bugfix
@@ -1,0 +1,1 @@
+Fix docker instances not starting due to being unable to load a dynamic library.

--- a/changelog.d/828.bugfix
+++ b/changelog.d/828.bugfix
@@ -1,1 +1,1 @@
-Fix docker instances not starting due to being unable to load a dynamic library.
+Fix Docker instances not starting due to being unable to load a dynamic library in the latest unstable image.


### PR DESCRIPTION
Fixes #827 

Matrix-appservice-bridge 5.0.0 brought in new changes (matrix-bot-sdk) which relies on compiled crypto modules. These modules do not appear to work properly on alpine.

```
Error: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /node_modules/@matrix-org/matrix-sdk-crypto-nodejs/matrix-sdk-crypto.linux-x64-musl.node)
    at Object.Module._extensions..node (node:internal/modules/cjs/loader:1189:18)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at Object.<anonymous> (/node_modules/@matrix-org/matrix-sdk-crypto-nodejs/index.js:159:31)
    at Module._compile (node:internal/modules/cjs/loader:1105:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1159:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12) {
  code: 'ERR_DLOPEN_FAILED'
}
```

Prior experience has taught me that alpine and native rust modules tend not to blend too well, so I'm going to say we just use debian-slim for our images. We do this for the Slack/IRC/Hookshot bridges already.