### PR TITLE
Add option to disable room topic echos from Matrix

### DIFF
--- a/changelog.d/836.feature
+++ b/changelog.d/836.feature
@@ -1,0 +1,1 @@
+Adds a config value, in order to disable forwarding room topic changes from Matrix to Discord (`disableRoomTopicNotifications`, false by default).

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -36,6 +36,8 @@ bridge:
   disableJoinLeaveNotifications: false
   # Disable Invite echos from matrix
   disableInviteNotifications: false
+  # Disable Room Topic echos from matrix
+  disableRoomTopicNotifications: false
   # Auto-determine the language of code blocks (this can be CPU-intensive)
   determineCodeLanguage: false
   # MXID of an admin user that will be PMd if the bridge experiences problems. Optional

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -30,6 +30,8 @@ properties:
             type: "boolean"
           disableInviteNotifications:
             type: "boolean"
+          disableRoomTopicNotifications:
+            type: "boolean"
           userActivity:
             type: "object"
             required: ["minUserActiveDays", "inactiveAfterDays"]

--- a/src/config.ts
+++ b/src/config.ts
@@ -97,6 +97,7 @@ class DiscordBridgeConfigBridge {
     public disableHereMention: boolean = false;
     public disableJoinLeaveNotifications: boolean = false;
     public disableInviteNotifications: boolean = false;
+    public disableRoomTopicNotifications: boolean = false;
     public determineCodeLanguage: boolean = false;
     public activityTracker: UserActivityTrackerConfig = UserActivityTrackerConfig.DEFAULT;
     public userLimit: number|null = null;

--- a/src/config.ts
+++ b/src/config.ts
@@ -80,7 +80,7 @@ export class DiscordBridgeConfig {
     }
 }
 
-class DiscordBridgeConfigBridge {
+export class DiscordBridgeConfigBridge {
     public domain: string;
     public homeserverUrl: string;
     public port: number;

--- a/src/matrixeventprocessor.ts
+++ b/src/matrixeventprocessor.ts
@@ -238,10 +238,11 @@ export class MatrixEventProcessor {
 
         const allowJoinLeave = !this.config.bridge.disableJoinLeaveNotifications;
         const allowInvite = !this.config.bridge.disableInviteNotifications;
+        const allowRoomTopic = !this.config.bridge.disableRoomTopicNotifications;
 
         if (event.type === "m.room.name") {
             msg += `set the name to \`${event.content!.name}\``;
-        } else if (event.type === "m.room.topic") {
+        } else if (event.type === "m.room.topic" && allowRoomTopic) {
             msg += `set the topic to \`${event.content!.topic}\``;
         } else if (event.type === "m.room.member") {
             const membership = event.content!.membership;
@@ -274,6 +275,9 @@ export class MatrixEventProcessor {
                 // Ignore anything else
                 return;
             }
+        } else {
+            // Ignore anything else
+            return;
         }
 
         msg += " on Matrix.";

--- a/test/test_matrixeventprocessor.ts
+++ b/test/test_matrixeventprocessor.ts
@@ -20,6 +20,7 @@ import * as Proxyquire from "proxyquire";
 import { MockMember } from "./mocks/member";
 import { MatrixEventProcessor, MatrixEventProcessorOpts } from "../src/matrixeventprocessor";
 import { DiscordBridgeConfig } from "../src/config";
+import { DiscordBridgeConfigBridge } from "../src/config";
 import { MockChannel } from "./mocks/channel";
 import { IMatrixEvent } from "../src/matrixtypes";
 import { AppserviceMock } from "./mocks/appservicemock";
@@ -154,7 +155,7 @@ let KICKBAN_HANDLED = false;
 let MESSAGE_SENT = false;
 let MESSAGE_EDITED = false;
 
-function createMatrixEventProcessor(storeMockResults = 0) {
+function createMatrixEventProcessor(storeMockResults = 0, configBridge = new DiscordBridgeConfigBridge()) {
     STATE_EVENT_MSG = "";
     MESSAGE_PROCCESS = "";
     KICKBAN_HANDLED = false;
@@ -173,6 +174,7 @@ function createMatrixEventProcessor(storeMockResults = 0) {
         OnUpdateUser: async () => { },
     };
     const config = new DiscordBridgeConfig();
+    config.bridge = configBridge;
 
     const store = {
         Get: (a, b) => {
@@ -354,6 +356,20 @@ describe("MatrixEventProcessor", () => {
             await processor.ProcessStateEvent(event);
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` set the topic to `Test Topic` on Matrix.");
         });
+        it("Should not echo topic changes", async () => {
+            const bridge = new DiscordBridgeConfigBridge();
+            bridge.disableRoomTopicNotifications = true;
+            const {processor} =  createMatrixEventProcessor(0, bridge);
+            const event = {
+                content: {
+                    topic: "Test Topic",
+                },
+                sender: "@user:localhost",
+                type: "m.room.topic",
+            } as IMatrixEvent;
+            await processor.ProcessStateEvent(event);
+            expect(STATE_EVENT_MSG).to.equal("");
+        });
         it("Should echo joins", async () => {
             const {processor} =  createMatrixEventProcessor();
             const event = {
@@ -366,6 +382,21 @@ describe("MatrixEventProcessor", () => {
             } as IMatrixEvent;
             await processor.ProcessStateEvent(event);
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` joined the room on Matrix.");
+        });
+        it("Should not echo joins", async () => {
+            const bridge = new DiscordBridgeConfigBridge();
+            bridge.disableJoinLeaveNotifications = true;
+            const {processor} =  createMatrixEventProcessor(0, bridge);
+            const event = {
+                content: {
+                    membership: "join",
+                },
+                sender: "@user:localhost",
+                type: "m.room.member",
+                unsigned: {},
+            } as IMatrixEvent;
+            await processor.ProcessStateEvent(event);
+            expect(STATE_EVENT_MSG).to.equal("");
         });
         it("Should echo invites", async () => {
             const {processor} =  createMatrixEventProcessor();
@@ -380,6 +411,22 @@ describe("MatrixEventProcessor", () => {
             } as IMatrixEvent;
             await processor.ProcessStateEvent(event);
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` invited `@user2:localhost` to the room on Matrix.");
+        });
+        it("Should not echo invites", async () => {
+            const bridge = new DiscordBridgeConfigBridge();
+            bridge.disableInviteNotifications = true;
+            const {processor} =  createMatrixEventProcessor(0, bridge);
+            const event = {
+                content: {
+                    membership: "invite",
+                },
+                sender: "@user:localhost",
+                state_key: "@user2:localhost",
+                type: "m.room.member",
+                unsigned: {},
+            } as IMatrixEvent;
+            await processor.ProcessStateEvent(event);
+            expect(STATE_EVENT_MSG).to.equal("");
         });
         it("Should echo kicks", async () => {
             const {processor} =  createMatrixEventProcessor();
@@ -408,6 +455,22 @@ describe("MatrixEventProcessor", () => {
             } as IMatrixEvent;
             await processor.ProcessStateEvent(event);
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` left the room on Matrix.");
+        });
+        it("Should not echo leaves", async () => {
+            const bridge = new DiscordBridgeConfigBridge();
+            bridge.disableJoinLeaveNotifications = true;
+            const {processor} =  createMatrixEventProcessor(0, bridge);
+            const event = {
+                content: {
+                    membership: "leave",
+                },
+                sender: "@user:localhost",
+                state_key: "@user:localhost",
+                type: "m.room.member",
+                unsigned: {},
+            } as IMatrixEvent;
+            await processor.ProcessStateEvent(event);
+            expect(STATE_EVENT_MSG).to.equal("");
         });
         it("Should echo bans", async () => {
             const {processor} =  createMatrixEventProcessor();


### PR DESCRIPTION
This PR adds another config value, in order to disable forwarding room topic echos on Matrix to Discord.