### PR TITLE
Do not rely on `age`, use origin_server_ts

### DIFF
--- a/changelog.d/842.bugfix
+++ b/changelog.d/842.bugfix
@@ -1,0 +1,1 @@
+Remove usage of unreliable field `age` on events, allowing the bridge to work with non-Synapse homeserver implementations.

--- a/src/matrixeventprocessor.ts
+++ b/src/matrixeventprocessor.ts
@@ -245,8 +245,8 @@ export class MatrixEventProcessor {
         } else if (event.type === "m.room.member") {
             const membership = event.content!.membership;
             const client = this.bridge.botIntent.underlyingClient;
-            const isNewJoin = event.unsigned.replaces_state === undefined ? true : (
-                await client.getEvent(event.room_id, event.unsigned.replaces_state)).content.membership !== "join";
+            const isNewJoin = event.unsigned?.replaces_state === undefined ? true : (
+                await client.getEvent(event.room_id, event.unsigned?.replaces_state)).content.membership !== "join";
             if (membership === "join") {
                 this.mxUserProfileCache.delete(`${event.room_id}:${event.sender}`);
                 this.mxUserProfileCache.delete(event.sender);

--- a/src/matrixeventprocessor.ts
+++ b/src/matrixeventprocessor.ts
@@ -92,11 +92,9 @@ export class MatrixEventProcessor {
      */
     public async OnEvent(event: IMatrixEvent, rooms: IRoomStoreEntry[]): Promise<void> {
         const remoteRoom = rooms[0];
-        if (event.unsigned.age > AGE_LIMIT) {
-            log.info(`Skipping event due to age ${event.unsigned.age} > ${AGE_LIMIT}`);
-            // throw new Unstable.EventTooOldError(
-            //     `Skipping event due to age ${event.unsigned.age} > ${AGE_LIMIT}`,
-            // );
+        const age = Date.now() - event.origin_server_ts;
+        if (age > AGE_LIMIT) {
+            log.info(`Skipping event due to age ${age} > ${AGE_LIMIT}`);
             return;
         }
         if (

--- a/src/matrixtypes.ts
+++ b/src/matrixtypes.ts
@@ -40,7 +40,7 @@ export interface IMatrixEvent {
     redacts?: string;
     replaces_state?: string;
     content?: IMatrixEventContent;
-    origin_server_ts?: number;
+    origin_server_ts: number;
     users?: any; // tslint:disable-line no-any
     users_default?: any; // tslint:disable-line no-any
     notifications?: any; // tslint:disable-line no-any

--- a/src/matrixtypes.ts
+++ b/src/matrixtypes.ts
@@ -40,7 +40,6 @@ export interface IMatrixEvent {
     redacts?: string;
     replaces_state?: string;
     content?: IMatrixEventContent;
-    unsigned?: any; // tslint:disable-line no-any
     origin_server_ts?: number;
     users?: any; // tslint:disable-line no-any
     users_default?: any; // tslint:disable-line no-any

--- a/src/matrixtypes.ts
+++ b/src/matrixtypes.ts
@@ -44,6 +44,9 @@ export interface IMatrixEvent {
     users?: any; // tslint:disable-line no-any
     users_default?: any; // tslint:disable-line no-any
     notifications?: any; // tslint:disable-line no-any
+    unsigned?: {
+        replaces_state: any; // tslint:disable-line no-any
+    }
 }
 
 export interface IMatrixMessage {

--- a/test/test_matrixeventprocessor.ts
+++ b/test/test_matrixeventprocessor.ts
@@ -24,7 +24,6 @@ import { MockChannel } from "./mocks/channel";
 import { IMatrixEvent } from "../src/matrixtypes";
 import { AppserviceMock } from "./mocks/appservicemock";
 import { Appservice } from "matrix-bot-sdk";
-import { RemoteStoreRoom } from "../src/db/roomstore";
 
 // we are a test file and thus need those
 /* tslint:disable:no-unused-expression max-file-line-count no-any */
@@ -32,11 +31,11 @@ import { RemoteStoreRoom } from "../src/db/roomstore";
 const TEST_TIMESTAMP = 1337;
 
 function buildRequest(eventData): IMatrixEvent {
-    if (eventData.unsigned === undefined) {
-        eventData.unsigned = {age: 0};
-    }
     if (eventData.sender === undefined) {
         eventData.sender = "@foobar:localhost";
+    }
+    if (!eventData.origin_server_ts) {
+        eventData.origin_server_ts = Date.now();
     }
     return eventData;
 }
@@ -362,7 +361,6 @@ describe("MatrixEventProcessor", () => {
                 },
                 sender: "@user:localhost",
                 type: "m.room.member",
-                unsigned: {},
             } as IMatrixEvent;
             await processor.ProcessStateEvent(event);
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` joined the room on Matrix.");
@@ -376,7 +374,6 @@ describe("MatrixEventProcessor", () => {
                 sender: "@user:localhost",
                 state_key: "@user2:localhost",
                 type: "m.room.member",
-                unsigned: {},
             } as IMatrixEvent;
             await processor.ProcessStateEvent(event);
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` invited `@user2:localhost` to the room on Matrix.");
@@ -390,7 +387,6 @@ describe("MatrixEventProcessor", () => {
                 sender: "@user:localhost",
                 state_key: "@user2:localhost",
                 type: "m.room.member",
-                unsigned: {},
             } as IMatrixEvent;
             await processor.ProcessStateEvent(event);
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` kicked `@user2:localhost` from the room on Matrix.");
@@ -404,7 +400,6 @@ describe("MatrixEventProcessor", () => {
                 sender: "@user:localhost",
                 state_key: "@user:localhost",
                 type: "m.room.member",
-                unsigned: {},
             } as IMatrixEvent;
             await processor.ProcessStateEvent(event);
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` left the room on Matrix.");
@@ -418,7 +413,6 @@ describe("MatrixEventProcessor", () => {
                 sender: "@user:localhost",
                 state_key: "@user2:localhost",
                 type: "m.room.member",
-                unsigned: {},
             } as IMatrixEvent;
             await processor.ProcessStateEvent(event);
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` banned `@user2:localhost` from the room on Matrix.");
@@ -908,13 +902,12 @@ This is the reply`,
             const {processor} =  createMatrixEventProcessor();
             let err;
             try {
-                await processor.OnEvent(buildRequest({unsigned: {age: AGE}}), []);
+                await processor.OnEvent(buildRequest({ origin_server_ts: Date.now() - AGE }), []);
             } catch (e) { err = e; }
             // TODO: Not supported yet.
             // expect(err).to.be.an.instanceof(Unstable.EventTooOldError);
         });
         it("should reject un-processable events", async () => {
-            const AGE = 900000; // 15 * 60 * 1000
             const {processor} =  createMatrixEventProcessor();
             let err;
             try {
@@ -922,7 +915,6 @@ This is the reply`,
                     buildRequest({
                         content: {},
                         type: "m.potato",
-                        unsigned: {age: AGE},
                     }),
                     [],
                 );


### PR DESCRIPTION
Fixes #841 

`age` is a unreliable field that old Matrix events included to determine the rough age of an event. It's [unreliable](https://github.com/matrix-org/synapse/issues/8429) however, so we should just use the reliable timestamp field.