### PR TITLE
Configurable usernames v2

### DIFF
--- a/changelog.d/851.feature
+++ b/changelog.d/851.feature
@@ -1,0 +1,1 @@
+Add options to configure how Matrix users get displayed on Discord.

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -115,6 +115,14 @@ ghosts:
     nickPattern: ":nick"
     # Pattern for the ghosts username, available is :username, :tag and :id
     usernamePattern: ":username#:tag"
+discordProxy:
+    # Pattern for the Matrix sender name in Discord messages.
+    # Available is :nick, :username, :displayname (the latter is :nick if the user has a nick, and the username if they don't).
+    namePattern: ":displayname"
+    # Fallback name pattern, if namePattern would be too long to set as a name.
+    # If this also ends up being too long, it's truncated.
+    # See namePattern for tags.
+    fallbackNamePattern: ":username"
 # Prometheus-compatible metrics endpoint
 metrics:
     enable: false

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -117,11 +117,11 @@ ghosts:
     usernamePattern: ":username#:tag"
 discordProxy:
     # Pattern for the Matrix sender name in Discord messages.
-    # Available is :nick, :username, :displayname (the latter is :nick if the user has a nick, and the username if they don't).
+    # Available is :nick, :username, :displayname (the latter is the users nickname if they have one, and the username if they don't).
     namePattern: ":displayname"
-    # Fallback name pattern, if namePattern would be too long to set as a name.
+    # Fallback name pattern, if "namePattern" would be too long to set as a name.
     # If this also ends up being too long, it's truncated.
-    # See namePattern for tags.
+    # Available is :nick, :username, :displayname (the latter is the users nickname if they have one, and the username if they don't).
     fallbackNamePattern: ":username"
 # Prometheus-compatible metrics endpoint
 metrics:

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -140,6 +140,13 @@ properties:
                 type: "string"
             usernamePattern:
                 type: "string"
+    discordProxy:
+      type: "object"
+      properties:
+        namePattern:
+          type: "string"
+        fallbackNamePattern:
+          type: "string"
     metrics:
         type: "object"
         properties:

--- a/src/config.ts
+++ b/src/config.ts
@@ -30,6 +30,7 @@ export class DiscordBridgeConfig {
     public channel: DiscordBridgeConfigChannel = new DiscordBridgeConfigChannel();
     public limits: DiscordBridgeConfigLimits = new DiscordBridgeConfigLimits();
     public ghosts: DiscordBridgeConfigGhosts = new DiscordBridgeConfigGhosts();
+    public discordProxy: DiscordBridgeConfigDiscordProxy = new DiscordBridgeConfigDiscordProxy();
     public metrics: DiscordBridgeConfigMetrics = new DiscordBridgeConfigMetrics();
 
     /**
@@ -164,6 +165,11 @@ export class LoggingFile {
 class DiscordBridgeConfigGhosts {
     public nickPattern: string = ":nick";
     public usernamePattern: string = ":username#:tag";
+}
+
+class DiscordBridgeConfigDiscordProxy {
+    public namePattern: string = ":displayname";
+    public fallbackNamePattern: string = ":username";
 }
 
 export class DiscordBridgeConfigMetrics {

--- a/src/matrixeventprocessor.ts
+++ b/src/matrixeventprocessor.ts
@@ -514,10 +514,10 @@ export class MatrixEventProcessor {
             // Let it fall through.
         }
 
+        let profileName = "";
         if (profile) {
-            if (profile.displayname &&
-                profile.displayname.length >= MIN_NAME_LENGTH &&
-                profile.displayname.length <= MAX_NAME_LENGTH) {
+            if (profile.displayname) {
+                profileName = profile.displayname;
                 displayName = profile.displayname;
             }
 
@@ -530,8 +530,24 @@ export class MatrixEventProcessor {
                 );
             }
         }
+
+        // Try to set the display name from the pattern; if it doesn't turn out to be too long:
+        let author = Util.ApplyPatternString(this.config.discordProxy.namePattern, {
+            nick: profileName,
+            displayname: displayName,
+            username: sender,
+        });
+        if (author.length >= MAX_NAME_LENGTH) {
+            // Otherwise fall back to fallback name pattern and truncate.
+            author = Util.ApplyPatternString(this.config.discordProxy.fallbackNamePattern, {
+                nick: profileName,
+                displayname: displayName,
+                username: sender,
+            }).substring(0, MAX_NAME_LENGTH)
+        }
+
         embed.setAuthor(
-            displayName.substring(0, MAX_NAME_LENGTH),
+            author,
             avatarUrl,
             `https://matrix.to/#/${sender}`,
         );

--- a/test/test_matrixeventprocessor.ts
+++ b/test/test_matrixeventprocessor.ts
@@ -154,7 +154,7 @@ let KICKBAN_HANDLED = false;
 let MESSAGE_SENT = false;
 let MESSAGE_EDITED = false;
 
-function createMatrixEventProcessor(storeMockResults = 0, configBridge = new DiscordBridgeConfigBridge()) {
+function createMatrixEventProcessor(storeMockResults = 0, bridgeConfig = new DiscordBridgeConfig()) {
     STATE_EVENT_MSG = "";
     MESSAGE_PROCCESS = "";
     KICKBAN_HANDLED = false;
@@ -172,8 +172,7 @@ function createMatrixEventProcessor(storeMockResults = 0, configBridge = new Dis
         OnMemberState: async () => { },
         OnUpdateUser: async () => { },
     };
-    const config = new DiscordBridgeConfig();
-    config.bridge = configBridge;
+    const config = bridgeConfig;
 
     const store = {
         Get: (a, b) => {
@@ -356,9 +355,9 @@ describe("MatrixEventProcessor", () => {
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` set the topic to `Test Topic` on Matrix.");
         });
         it("Should not echo topic changes", async () => {
-            const bridge = new DiscordBridgeConfigBridge();
-            bridge.disableRoomTopicNotifications = true;
-            const {processor} =  createMatrixEventProcessor(0, bridge);
+            const config = new DiscordBridgeConfig();
+            config.bridge.disableRoomTopicNotifications = true;
+            const {processor} =  createMatrixEventProcessor(0, config);
             const event = {
                 content: {
                     topic: "Test Topic",
@@ -382,9 +381,9 @@ describe("MatrixEventProcessor", () => {
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` joined the room on Matrix.");
         });
         it("Should not echo joins", async () => {
-            const bridge = new DiscordBridgeConfigBridge();
-            bridge.disableJoinLeaveNotifications = true;
-            const {processor} =  createMatrixEventProcessor(0, bridge);
+            const config = new DiscordBridgeConfig();
+            config.bridge.disableJoinLeaveNotifications = true;
+            const {processor} =  createMatrixEventProcessor(0, config);
             const event = {
                 content: {
                     membership: "join",
@@ -410,9 +409,9 @@ describe("MatrixEventProcessor", () => {
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` invited `@user2:localhost` to the room on Matrix.");
         });
         it("Should not echo invites", async () => {
-            const bridge = new DiscordBridgeConfigBridge();
-            bridge.disableInviteNotifications = true;
-            const {processor} =  createMatrixEventProcessor(0, bridge);
+            const config = new DiscordBridgeConfig();
+            config.bridge.disableInviteNotifications = true;
+            const {processor} =  createMatrixEventProcessor(0, config);
             const event = {
                 content: {
                     membership: "invite",
@@ -452,9 +451,9 @@ describe("MatrixEventProcessor", () => {
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` left the room on Matrix.");
         });
         it("Should not echo leaves", async () => {
-            const bridge = new DiscordBridgeConfigBridge();
-            bridge.disableJoinLeaveNotifications = true;
-            const {processor} =  createMatrixEventProcessor(0, bridge);
+            const config = new DiscordBridgeConfig();
+            config.bridge.disableJoinLeaveNotifications = true;
+            const {processor} =  createMatrixEventProcessor(0, config);
             const event = {
                 content: {
                     membership: "leave",
@@ -552,7 +551,7 @@ describe("MatrixEventProcessor", () => {
             const config = new DiscordBridgeConfig();
             config.discordProxy.namePattern = ":nick -- :username";
 
-            const {processor} =  createMatrixEventProcessor(0, config.bridge);
+            const {processor} =  createMatrixEventProcessor(0, config);
 
             const embeds = await processor.EventToEmbed({
                 content: {
@@ -569,7 +568,7 @@ describe("MatrixEventProcessor", () => {
             config.discordProxy.namePattern = ":nick -------------- :username";
             config.discordProxy.fallbackNamePattern = "fallback :nick :username.";
 
-            const {processor} =  createMatrixEventProcessor(0, config.bridge);
+            const {processor} =  createMatrixEventProcessor(0, config);
 
             const embeds = await processor.EventToEmbed({
                 content: {
@@ -585,7 +584,7 @@ describe("MatrixEventProcessor", () => {
             const config = new DiscordBridgeConfig();
             config.discordProxy.namePattern = ":nick -- :username";
 
-            const {processor} =  createMatrixEventProcessor(0, config.bridge);
+            const {processor} =  createMatrixEventProcessor(0, config);
 
             const embeds = await processor.EventToEmbed({
                 content: {
@@ -601,7 +600,7 @@ describe("MatrixEventProcessor", () => {
             const config = new DiscordBridgeConfig();
             config.discordProxy.namePattern = ":displayname";
 
-            const {processor} =  createMatrixEventProcessor(0, config.bridge);
+            const {processor} =  createMatrixEventProcessor(0, config);
 
             const embeds = await processor.EventToEmbed({
                 content: {
@@ -617,7 +616,7 @@ describe("MatrixEventProcessor", () => {
             const config = new DiscordBridgeConfig();
             config.discordProxy.namePattern = ":displayname";
 
-            const {processor} =  createMatrixEventProcessor(0, config.bridge);
+            const {processor} =  createMatrixEventProcessor(0, config);
 
             const embeds = await processor.EventToEmbed({
                 content: {

--- a/test/test_matrixeventprocessor.ts
+++ b/test/test_matrixeventprocessor.ts
@@ -552,7 +552,7 @@ describe("MatrixEventProcessor", () => {
             const config = new DiscordBridgeConfig();
             config.discordProxy.namePattern = ":nick -- :username";
 
-            const {processor} =  createMatrixEventProcessor(0, config);
+            const {processor} =  createMatrixEventProcessor(0, config.bridge);
 
             const embeds = await processor.EventToEmbed({
                 content: {
@@ -569,7 +569,7 @@ describe("MatrixEventProcessor", () => {
             config.discordProxy.namePattern = ":nick -------------- :username";
             config.discordProxy.fallbackNamePattern = "fallback :nick :username.";
 
-            const {processor} =  createMatrixEventProcessor(0, config);
+            const {processor} =  createMatrixEventProcessor(0, config.bridge);
 
             const embeds = await processor.EventToEmbed({
                 content: {
@@ -585,7 +585,7 @@ describe("MatrixEventProcessor", () => {
             const config = new DiscordBridgeConfig();
             config.discordProxy.namePattern = ":nick -- :username";
 
-            const {processor} =  createMatrixEventProcessor(0, config);
+            const {processor} =  createMatrixEventProcessor(0, config.bridge);
 
             const embeds = await processor.EventToEmbed({
                 content: {
@@ -601,7 +601,7 @@ describe("MatrixEventProcessor", () => {
             const config = new DiscordBridgeConfig();
             config.discordProxy.namePattern = ":displayname";
 
-            const {processor} =  createMatrixEventProcessor(0, config);
+            const {processor} =  createMatrixEventProcessor(0, config.bridge);
 
             const embeds = await processor.EventToEmbed({
                 content: {
@@ -617,7 +617,7 @@ describe("MatrixEventProcessor", () => {
             const config = new DiscordBridgeConfig();
             config.discordProxy.namePattern = ":displayname";
 
-            const {processor} =  createMatrixEventProcessor(0, config);
+            const {processor} =  createMatrixEventProcessor(0, config.bridge);
 
             const embeds = await processor.EventToEmbed({
                 content: {


### PR DESCRIPTION
@theCapypara unfortunately doesn't have the time for a while to implement the requested changes, so with their permission I'm reopening their changes as a new PR in order to get the changes faster in.

This PR fixes #805 by implementing options to change how Matrix users look on Discord (and add tests for those)

Obsoletes #809 