### PR TITLE
feat: add listusers command

### DIFF
--- a/changelog.d/854.feature
+++ b/changelog.d/854.feature
@@ -1,0 +1,1 @@
+Add listusers command to Discord bot to list the users on the Matrix side. Thanks to @SethFalco!

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -144,7 +144,7 @@ export class DiscordBot {
         this.mxEventProcessor = new MatrixEventProcessor(
             new MatrixEventProcessorOpts(config, bridge, this, store),
         );
-        this.discordCommandHandler = new DiscordCommandHandler(bridge, this);
+        this.discordCommandHandler = new DiscordCommandHandler(bridge, this, config);
         // init vars
         this.sentMessages = [];
         this.discordMessageQueue = {};

--- a/test/mocks/appservicemock.ts
+++ b/test/mocks/appservicemock.ts
@@ -182,6 +182,13 @@ class MatrixClientMock extends AppserviceMockBase {
         super();
     }
 
+    public getPresenceStatusFor(userId: string) {
+        this.funcCalled("getPresenceStatusFor", userId);
+        return {
+            state: "online"
+        }
+    }
+
     public banUser(roomId: string, userId: string) {
         this.funcCalled("banUser", roomId, userId);
     }

--- a/test/mocks/channel.ts
+++ b/test/mocks/channel.ts
@@ -40,6 +40,10 @@ export class MockChannel {
     public permissionsFor(member: MockMember) {
         return new Permissions(Permissions.FLAGS.MANAGE_WEBHOOKS as PermissionResolvable);
     }
+
+    public toString(): string {
+        return `<#${this.id}>`;
+    }
 }
 
 export class MockTextChannel extends TextChannel {

--- a/test/mocks/guild.ts
+++ b/test/mocks/guild.ts
@@ -57,4 +57,8 @@ export class MockGuild {
     public _mockAddMember(member: MockMember) {
         this.members.cache.set(member.id, member);
     }
+
+    public toString(): string {
+        return `<#${this.id}>`;
+    }
 }

--- a/test/structures/test_lock.ts
+++ b/test/structures/test_lock.ts
@@ -16,7 +16,6 @@ limitations under the License.
 
 import { expect } from "chai";
 import { Lock } from "../../src/structures/lock";
-import { Util } from "../../src/util";
 
 const LOCKTIMEOUT = 300;
 


### PR DESCRIPTION
<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honestly).
-->

Adds the `listusers` command to the Discord bot, which will list the users on the Matrix side. Context and motivation is written up on the related issue at the bottom.

On the side, I also:
* Capitalized "matrix" on some lines as Matrix is a noun.
* Added line breaks between test cases.
* Make the `#Process` command return the response as I believe this makes sense, and makes testing command output a lot easier.

## Screenshots

![image](https://user-images.githubusercontent.com/22801583/191548346-26eed2ca-421c-45f3-b9ed-b60dbbbf4525.png)
> Output when there are no Matrix users in the channel. This originally said "There are **no** users on the Matrix side.", but later decided **0** was better, it's less code so why not. Feedback welcome!

![image](https://user-images.githubusercontent.com/22801583/192563450-ddc2e797-c32a-4e0e-acc2-563ce87510f2.png)
> Output when there is 1 Matrix user in the channel with `bridge.disablePresence: false`.

![image](https://user-images.githubusercontent.com/22801583/192571658-d2dec08a-42b1-4eec-8164-cc0a40be22d6.png)
> Tail of the output when there are too many Matrix users, so the output is over 2,000+ characters with `bridge.disablePresence: true`. 
> 
> Referenced how the UI in Element presents it, except I format numbers, i.e. 1,610, not 1610:
> ![image](https://user-images.githubusercontent.com/22801583/192573998-fcf0de46-2278-4459-b103-217ae3cfcb9c.png)

## Draft

### Open Questions

* Can anything be moved into general helpers or utilities to reduce the size of the command? The command came out a bit fat, exploring the project to see where I can split this up, but advice is welcome.
* Is it fine to reuse `bridge.disablePresence` for whether the output should include user presence in the response, or should we introduce a new setting?
* Can we think of a good structure to include other info like last activity (_last active 2 hours ago_) or status messages? I'd like to, but am wary that the output will get too cluttered.
* Should we have caching of presence here? (I'm thinking maybe that belongs in the SDK?)

## Decisions

### Prefixed Message

Prefixed a message at the top to make sure Discord users understand that the list can change between channels in the same server. They are accustomed to guild and channels being coupled together. This reminds them a Matrix user can choose which chat rooms to join, so being in one doesn't mean they're in others.

### Handling 2,000+ Characters

A proposal in the issue was made that we could upload a file instead. [[source](https://github.com/matrix-org/matrix-appservice-discord/issues/853#issuecomment-1252340735)]
I've read the Discord docs, file previews are up to 100 lines when expanded, and up to 50 kb (presumably around 50,000~ characters) when previewed. [[source](https://support.discord.com/hc/en-us/articles/1500005466681-File-Preview)]

On Discord, guild and user settings won't let disable file previews, so that doesn't hinder this either, but I only checked on desktop, not mobile.

I didn't implement this since I thought the file approach looked clunky. Numerous users have expressed that the important thing is knowing how many people are on Matrix. While for small communities names are nice, for larger communities the names are just noise, they just want to know how many people are on the other side.

This makes me think coming up with a good and predictable output has more value than changing it based on the number of users or the online state of users. For example, users going from online (6 chars) to offline (7 chars), which makes the output over 2,000 characters and so sends a file instead. It's annoying if the output format changes unpredictably.

### Presence Config

The output can display presence, since this seems valuable for smaller communities or hosts, but might not scale to larger ones with thousands of users in a single chat room.

By adding the option, people self-hosting for their community can enable it safely, but public hosts like [t2bot](https://t2bot.io/discord/) may want to disable it.

### Presence UI

Original plan was to replace the bullet points with 🟢, 🟠, and ⚫ for `"online"`, `"unavailable"`, and `"offline"` respectively, however that looked ugly and was visually inaccessible depending on the client color-scheme. Then I experimented with ⊕, ⊘, and ⊖, as this uses the font color, but text-to-speech (screen readers) won't read it (tested with [eSpeak NG](https://github.com/espeak-ng/espeak-ng/)), and it's unclear what any of the icons mean.

In the end, we decided the best approach was to just append a hyphen followed by the state to the end of the line if the presence was available. This is visually accessible, screen reader friendly, and doesn't require a legend to understand.

When a user's presence is `"unavailable"`, we display **Idle** as this term will be more familiar to Discord users.

### Sorting Results

* Online Presence (Online, Idle, Offline, Unknown)
* Display Name, case-sensitive (If not set, end of list sorted by MXID.)
* MXID

## Related

* Closes https://github.com/matrix-org/matrix-appservice-discord/issues/853