### PR TITLE
feat: add discord > matrix reaction support

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ In a vague order of what is coming up next
      - [x] Audio/Video content
      - [ ] Typing notifs (**Not supported, requires syncing**)
      - [x] User Profiles
+     - [ ] Reactions
  - Discord -> Matrix
      - [x] Text content
      - [x] Image content
@@ -152,6 +153,7 @@ In a vague order of what is coming up next
      - [x] User Profiles
      - [x] Presence
      - [x] Per-guild display names.
+     - [x] Reactions
  - [x] Group messages
  - [ ] Third Party Lookup
     - [x] Rooms

--- a/changelog.d/862.feature
+++ b/changelog.d/862.feature
@@ -1,0 +1,1 @@
+Adds one-way reaction support from Discord -> Matrix. Thanks to @SethFalco!

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -263,6 +263,21 @@ export class DiscordBot {
                 await this.channelSync.OnGuildDelete(guild);
             } catch (err) { log.error("Exception thrown while handling \"guildDelete\" event", err); }
         });
+        client.on("messageReactionAdd", async (reaction, user) => {
+            try {
+                await this.OnMessageReactionAdd(reaction, user);
+            } catch (err) { log.error("Exception thrown while handling \"messageReactionAdd\" event", err); }
+        });
+        client.on("messageReactionRemove", async (reaction, user) => {
+            try {
+                await this.OnMessageReactionRemove(reaction, user);
+            } catch (err) { log.error("Exception thrown while handling \"messageReactionRemove\" event", err); }
+        });
+        client.on("messageReactionRemoveAll", async (message) => {
+            try {
+                await this.OnMessageReactionRemoveAll(message);
+            } catch (err) { log.error("Exception thrown while handling \"messageReactionRemoveAll\" event", err); }
+        });
 
         // Due to messages often arriving before we get a response from the send call,
         // messages get delayed from discord. We use Util.DelayedPromise to handle this.
@@ -1175,6 +1190,143 @@ export class DiscordBot {
         }
         newMsg.content = `Edit: ${newMsg.content}`;
         await this.OnMessage(newMsg);
+    }
+
+    public async OnMessageReactionAdd(reaction: Discord.MessageReaction, user: Discord.User | Discord.PartialUser) {
+        const message = reaction.message;
+        log.info(`Got message reaction add event for ${message.id} with ${reaction.emoji.name}`);
+
+        let rooms: string[];
+
+        try {
+            rooms = await this.channelSync.GetRoomIdsFromChannel(message.channel);
+
+            if (rooms === null) {
+                throw Error();
+            }
+        } catch (err) {
+            log.verbose("No bridged rooms to send message to. Oh well.");
+            MetricPeg.get.requestOutcome(message.id, true, "dropped");
+            return;
+        }
+
+        const intent = this.GetIntentFromDiscordMember(user);
+        await intent.ensureRegistered();
+        this.userActivity.updateUserActivity(intent.userId);
+
+        const storeEvent = await this.store.Get(DbEvent, {
+            discord_id: message.id
+        });
+
+        if (!storeEvent?.Result) {
+            return;
+        }
+
+        while (storeEvent.Next()) {
+            const matrixIds = storeEvent.MatrixId.split(";");
+
+            for (const room of rooms) {
+                const reactionEventId = await intent.underlyingClient.unstableApis.addReactionToEvent(
+                    room,
+                    matrixIds[0],
+                    reaction.emoji.id ? `:${reaction.emoji.name}:` : reaction.emoji.name
+                );
+
+                const event = new DbEvent();
+                event.MatrixId = `${reactionEventId};${room}`;
+                event.DiscordId = message.id;
+                event.ChannelId = message.channel.id;
+                if (message.guild) {
+                    event.GuildId = message.guild.id;
+                }
+
+                await this.store.Insert(event);
+            }
+        }
+    }
+
+    public async OnMessageReactionRemove(reaction: Discord.MessageReaction, user: Discord.User | Discord.PartialUser) {
+        const message = reaction.message;
+        log.info(`Got message reaction remove event for ${message.id} with ${reaction.emoji.name}`);
+
+        const intent = this.GetIntentFromDiscordMember(user);
+        await intent.ensureRegistered();
+        this.userActivity.updateUserActivity(intent.userId);
+
+        const storeEvent = await this.store.Get(DbEvent, {
+            discord_id: message.id,
+        });
+
+        if (!storeEvent?.Result) {
+            return;
+        }
+
+        while (storeEvent.Next()) {
+            const [ eventId, roomId ] = storeEvent.MatrixId.split(";");
+            const underlyingClient = intent.underlyingClient;
+
+            const { chunk } = await underlyingClient.unstableApis.getRelationsForEvent(
+                roomId,
+                eventId,
+                "m.annotation"
+            );
+
+            const event = chunk.find((event) => {
+                if (event.sender !== intent.userId) {
+                    return false;
+                }
+
+                return event.content["m.relates_to"].key === reaction.emoji.name;
+            });
+
+            if (!event) {
+                return;
+            }
+
+            const { room_id, event_id } = event;
+
+            try {
+                await underlyingClient.redactEvent(room_id, event_id);
+            } catch (ex) {
+                log.warn(`Failed to delete ${storeEvent.DiscordId}, retrying as bot`);
+                try {
+                    await this.bridge.botIntent.underlyingClient.redactEvent(room_id, event_id);
+                } catch (ex) {
+                    log.warn(`Failed to delete ${event_id}, giving up`);
+                }
+            }
+        }
+    }
+
+    public async OnMessageReactionRemoveAll(message: Discord.Message | Discord.PartialMessage) {
+        log.info(`Got message reaction remove all event for ${message.id}`);
+
+        const storeEvent = await this.store.Get(DbEvent, {
+            discord_id: message.id,
+        });
+
+        if (!storeEvent?.Result) {
+            return;
+        }
+
+        while (storeEvent.Next()) {
+            const [ eventId, roomId ] = storeEvent.MatrixId.split(";");
+            const underlyingClient = this.bridge.botIntent.underlyingClient;
+
+            const { chunk } = await underlyingClient.unstableApis.getRelationsForEvent(
+                roomId,
+                eventId,
+                "m.annotation"
+            );
+
+            await Promise.all(chunk.map(async (event) => {
+                try {
+                    return await underlyingClient.redactEvent(event.room_id, event.event_id);
+                } catch (ex) {
+                    log.warn(`Failed to delete ${event.event_id}, giving up`);
+                }
+            }));
+        }
     }
 
     private async DeleteDiscordMessage(msg: Discord.Message) {

--- a/src/db/dbdataevent.ts
+++ b/src/db/dbdataevent.ts
@@ -19,7 +19,9 @@ import { IDbDataMany } from "./dbdatainterface";
 import { ISqlCommandParameters } from "./connector";
 
 export class DbEvent implements IDbDataMany {
+    /** Matrix ID of event. */
     public MatrixId: string;
+    /** Discord ID of the relevant message associated with this event. */
     public DiscordId: string;
     public GuildId: string;
     public ChannelId: string;

--- a/src/db/dbdataevent.ts
+++ b/src/db/dbdataevent.ts
@@ -19,7 +19,7 @@ import { IDbDataMany } from "./dbdatainterface";
 import { ISqlCommandParameters } from "./connector";
 
 export class DbEvent implements IDbDataMany {
-    /** Matrix ID of event. */
+    /** ID associated with the event in the format "MatrixID:RoomID". */
     public MatrixId: string;
     /** Discord ID of the relevant message associated with this event. */
     public DiscordId: string;

--- a/test/mocks/appservicemock.ts
+++ b/test/mocks/appservicemock.ts
@@ -146,7 +146,7 @@ export class AppserviceMock extends AppserviceMockBase {
 
 class IntentMock extends AppserviceMockBase {
     public readonly underlyingClient: MatrixClientMock;
-    constructor(private opts: IAppserviceMockOpts = {}, private id: string) {
+    constructor(private opts: IAppserviceMockOpts = {}, public userId: string) {
         super();
         this.underlyingClient = new MatrixClientMock(opts);
     }
@@ -177,9 +177,10 @@ class IntentMock extends AppserviceMockBase {
 }
 
 class MatrixClientMock extends AppserviceMockBase {
-
+    public readonly unstableApis: UnstableApis;
     constructor(private opts: IAppserviceMockOpts = {}) {
         super();
+        this.unstableApis = new UnstableApis();
     }
 
     public banUser(roomId: string, userId: string) {
@@ -275,5 +276,20 @@ class MatrixClientMock extends AppserviceMockBase {
 
     public async setPresenceStatus(presence: string, status: string) {
         this.funcCalled("setPresenceStatus", presence, status);
+    }
+
+    public async redactEvent(roomId: string, eventId: string, reason?: string | null) {
+        this.funcCalled("redactEvent", roomId, eventId, reason);
+    }
+}
+
+class UnstableApis extends AppserviceMockBase {
+
+    public async addReactionToEvent(roomId: string, eventId: string, emoji: string) {
+        this.funcCalled("addReactionToEvent", roomId, eventId, emoji);
+    }
+
+    public async getRelationsForEvent(roomId: string, eventId: string, relationType?: string, eventType?: string): Promise<any> {
+        this.funcCalled("getRelationsForEvent", roomId, eventId, relationType, eventType);
     }
 }

--- a/test/mocks/message.ts
+++ b/test/mocks/message.ts
@@ -24,17 +24,23 @@ import { MockCollection } from "./collection";
 export class MockMessage {
     public attachments = new MockCollection<string, any>();
     public embeds: any[] = [];
-    public content = "";
+    public content: string;
     public channel: Discord.TextChannel | undefined;
     public guild: Discord.Guild | undefined;
     public author: MockUser;
     public mentions: any = {};
-    constructor(channel?: Discord.TextChannel) {
+
+    constructor(
+        channel?: Discord.TextChannel,
+        content: string = "",
+        author: MockUser = new MockUser("123456"),
+    ) {
         this.mentions.everyone = false;
         this.channel = channel;
         if (channel && channel.guild) {
             this.guild = channel.guild;
         }
-        this.author = new MockUser("123456");
+        this.content = content;
+        this.author = author;
     }
 }

--- a/test/mocks/reaction.ts
+++ b/test/mocks/reaction.ts
@@ -1,0 +1,16 @@
+import { MockTextChannel } from './channel';
+import { MockEmoji } from './emoji';
+import { MockMessage } from './message';
+
+/* tslint:disable:no-unused-expression max-file-line-count no-any */
+export class MockReaction {
+    public message: MockMessage;
+    public emoji: MockEmoji;
+    public channel: MockTextChannel;
+
+    constructor(message: MockMessage, emoji: MockEmoji, channel: MockTextChannel) {
+        this.message = message;
+        this.emoji = emoji;
+        this.channel = channel;
+    }
+}

--- a/test/test_discordbot.ts
+++ b/test/test_discordbot.ts
@@ -476,6 +476,9 @@ describe("DiscordBot", () => {
             discord.userActivity = {
                 updateUserActivity: () => { }
             };
+            discord.userSync = {
+                JoinRoom: async () => { },
+            };
             discord.GetIntentFromDiscordMember = () => {
                 return mockBridge.getIntent(author.id);
             }


### PR DESCRIPTION
### Related

* Closes https://github.com/matrix-org/matrix-appservice-discord/issues/469
* Closes https://github.com/matrix-org/matrix-appservice-discord/pull/784

Adds reaction support in one direction (Discord → Matrix).

Supports:
* Adding reactions
* Removing reactions
* Removing all reactions

There is an "edge-case" with some emotes.

Here is a thumbs-up emoji on Discord: 👍 (Base64: 8J+RjQo=)
Here is a thumbs-up emoji on Element: 👍️ (Base64: 8J+Rje+4jwo=)

If someone reacts with a thumbs-up from Discord, then someone clicks that reaction in Element (and presumably any Matrix client) it's handled perfectly fine.

However, if a user separately goes through the Element interface to do a thumbs-up emoji, because it's technically a different character, you'll see 2 separate reactions for a thumbs-up.

![image](https://user-images.githubusercontent.com/22801583/194762106-1ff83df3-041a-4634-bbd9-15b9fafcbda5.png)
> When a Discord user does a thumbs-up, and an Element users manually performs a thumbs-up without clicking the pre-existing reaction.

### Notes

There are a few ways we can approach bridging reactions with custom emojis.

| | | |
|---|---|---
| name | But on Discord custom emotes can have the same name, so if the same user does multiple reactions with emojis with the same name, it'll only come through as one. If they do 2 reactions, then remove one, Discord will show the other, while Matrix will show neither.
| name:id | But on Discord, people can rename emotes. So if they react, then rename the emote, then remove the reaction, it will count as a different emote and won't be removed on the Matrix side.
| id | But on Matrix, this is basically a meaningless number, at that point we might as well not bridge custom emojis at all.

It looks like in future it should be supported to use external images as reactions via MXC URLs. I don't do this yet because the `shortcode` is not exposed in the SDK and it's not clearly documented behavior, but in future can update the bridge to support that.

Based on what I've seen, others use the format `:name:` for the `shortcode` property. Based on this, I've decided to use the same format already. That way when we're in a position to support MXC URLs and the `shortcode` property, we can just move the value of `key` to `shortcode` for those cases. 

### Screenshots

![image](https://user-images.githubusercontent.com/22801583/196972373-183be6ae-48ea-4c08-a3b7-1997567494ea.png)
> A message and 3 reactions all sent from Discord.

![image](https://user-images.githubusercontent.com/22801583/196972341-d029b96c-6c4e-413b-98f4-b3b1bc076f2f.png)
> How the same message/reactions appear on Matrix when bridged.

### Notes

* `getRelationsForEvent` was moved out of `unstableApis` in the **main** branch for **matrix-bot-sdk**. Eventually, when we update to a version of **matrix-appservice-bridge** that uses that version we should switch it out stop using it from `unstableApis`.