### PR TITLE
Add more configs to disable various Matrix state changes

### DIFF
--- a/changelog.d/867.feature
+++ b/changelog.d/867.feature
@@ -1,0 +1,1 @@
+Implement config values, in order to disable forwarding room name changes, bans and kicks from Matrix to Discord.

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -34,8 +34,14 @@ bridge:
   disableReadReceipts: false
   # Disable Join Leave echos from matrix
   disableJoinLeaveNotifications: false
+  # Disable Ban echos from matrix
+  disableBanNotifications: false
+  # Disable Kick echos from matrix
+  disableKickNotifications: false
   # Disable Invite echos from matrix
   disableInviteNotifications: false
+# Disable Room Name change echos from matrix
+  disableRoomNameNotifications: false
   # Disable Room Topic echos from matrix
   disableRoomTopicNotifications: false
   # Auto-determine the language of code blocks (this can be CPU-intensive)

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -28,7 +28,13 @@ properties:
             type: "boolean"
           disableJoinLeaveNotifications:
             type: "boolean"
+          disableBanNotifications:
+            type: "boolean"
+          disableKickNotifications:
+            type: "boolean"
           disableInviteNotifications:
+            type: "boolean"
+          disableRoomNameNotifications:
             type: "boolean"
           disableRoomTopicNotifications:
             type: "boolean"

--- a/src/config.ts
+++ b/src/config.ts
@@ -96,7 +96,10 @@ export class DiscordBridgeConfigBridge {
     public disableEveryoneMention: boolean = false;
     public disableHereMention: boolean = false;
     public disableJoinLeaveNotifications: boolean = false;
+    public disableBanNotifications: boolean = false;
+    public disableKickNotifications: boolean = false;
     public disableInviteNotifications: boolean = false;
+    public disableRoomNameNotifications: boolean = false;
     public disableRoomTopicNotifications: boolean = false;
     public determineCodeLanguage: boolean = false;
     public activityTracker: UserActivityTrackerConfig = UserActivityTrackerConfig.DEFAULT;

--- a/src/matrixeventprocessor.ts
+++ b/src/matrixeventprocessor.ts
@@ -268,7 +268,7 @@ export class MatrixEventProcessor {
                 msg += `invited \`${event.state_key}\` to the room`;
             } else if (membership === "leave" && event.state_key !== event.sender && allowKick) {
                 msg += `kicked \`${event.state_key}\` from the room`;
-            } else if (membership === "leave" && allowJoinLeave) {
+            } else if (membership === "leave" && event.state_key === event.sender && allowJoinLeave) {
                 msg += "left the room";
             } else if (membership === "ban" && allowBan) {
                 msg += `banned \`${event.state_key}\` from the room`;

--- a/src/matrixeventprocessor.ts
+++ b/src/matrixeventprocessor.ts
@@ -236,9 +236,12 @@ export class MatrixEventProcessor {
 
         const allowJoinLeave = !this.config.bridge.disableJoinLeaveNotifications;
         const allowInvite = !this.config.bridge.disableInviteNotifications;
+        const allowRoomName = !this.config.bridge.disableRoomNameNotifications;
         const allowRoomTopic = !this.config.bridge.disableRoomTopicNotifications;
+        const allowBan = !this.config.bridge.disableBanNotifications;
+        const allowKick = !this.config.bridge.disableKickNotifications;
 
-        if (event.type === "m.room.name") {
+        if (event.type === "m.room.name" && allowRoomName) {
             msg += `set the name to \`${event.content!.name}\``;
         } else if (event.type === "m.room.topic" && allowRoomTopic) {
             msg += `set the topic to \`${event.content!.topic}\``;
@@ -263,11 +266,11 @@ export class MatrixEventProcessor {
                 msg += "joined the room";
             } else if (membership === "invite" && allowInvite) {
                 msg += `invited \`${event.state_key}\` to the room`;
-            } else if (membership === "leave" && event.state_key !== event.sender) {
+            } else if (membership === "leave" && event.state_key !== event.sender && allowKick) {
                 msg += `kicked \`${event.state_key}\` from the room`;
             } else if (membership === "leave" && allowJoinLeave) {
                 msg += "left the room";
-            } else if (membership === "ban") {
+            } else if (membership === "ban" && allowBan) {
                 msg += `banned \`${event.state_key}\` from the room`;
             } else {
                 // Ignore anything else

--- a/test/test_matrixeventprocessor.ts
+++ b/test/test_matrixeventprocessor.ts
@@ -344,9 +344,9 @@ describe("MatrixEventProcessor", () => {
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` set the name to `Test Name` on Matrix.");
         });
         it("Should not echo name changes", async () => {
-            const config = new DiscordBridgeConfig();
-            config.bridge.disableRoomNameNotifications = true;
-            const {processor} =  createMatrixEventProcessor();
+            const bridge = new DiscordBridgeConfigBridge();
+            bridge.disableRoomNameNotifications = true;
+            const {processor} =  createMatrixEventProcessor(0, bridge);
             const event = {
                 content: {
                     name: "Test Name",
@@ -453,8 +453,8 @@ describe("MatrixEventProcessor", () => {
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` kicked `@user2:localhost` from the room on Matrix.");
         });
         it("Should not echo kicks", async () => {
-            const config = new DiscordBridgeConfig();
-            config.bridge.disableKickNotifications = true;
+            const bridge = new DiscordBridgeConfigBridge();
+            bridge.disableKickNotifications = true;
             const {processor} =  createMatrixEventProcessor(0, bridge);
             const event = {
                 content: {
@@ -510,8 +510,8 @@ describe("MatrixEventProcessor", () => {
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` banned `@user2:localhost` from the room on Matrix.");
         });
         it("Should not echo bans", async () => {
-            const config = new DiscordBridgeConfig();
-            config.bridge.disableBanNotifications = true;
+            const bridge = new DiscordBridgeConfigBridge();
+            bridge.disableBanNotifications = true;
             const {processor} =  createMatrixEventProcessor(0, bridge);
             const event = {
                 content: {

--- a/test/test_matrixeventprocessor.ts
+++ b/test/test_matrixeventprocessor.ts
@@ -343,6 +343,20 @@ describe("MatrixEventProcessor", () => {
             await processor.ProcessStateEvent(event);
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` set the name to `Test Name` on Matrix.");
         });
+        it("Should not echo name changes", async () => {
+            const config = new DiscordBridgeConfig();
+            config.bridge.disableRoomNameNotifications = true;
+            const {processor} =  createMatrixEventProcessor();
+            const event = {
+                content: {
+                    name: "Test Name",
+                },
+                sender: "@user:localhost",
+                type: "m.room.name",
+            } as IMatrixEvent;
+            await processor.ProcessStateEvent(event);
+            expect(STATE_EVENT_MSG).to.equal("");
+        });
         it("Should echo topic changes", async () => {
             const {processor} =  createMatrixEventProcessor();
             const event = {
@@ -438,6 +452,21 @@ describe("MatrixEventProcessor", () => {
             await processor.ProcessStateEvent(event);
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` kicked `@user2:localhost` from the room on Matrix.");
         });
+        it("Should not echo kicks", async () => {
+            const config = new DiscordBridgeConfig();
+            config.bridge.disableKickNotifications = true;
+            const {processor} =  createMatrixEventProcessor(0, bridge);
+            const event = {
+                content: {
+                    membership: "leave",
+                },
+                sender: "@user:localhost",
+                state_key: "@user2:localhost",
+                type: "m.room.member",
+            } as IMatrixEvent;
+            await processor.ProcessStateEvent(event);
+            expect(STATE_EVENT_MSG).to.equal("");
+        });
         it("Should echo leaves", async () => {
             const {processor} =  createMatrixEventProcessor();
             const event = {
@@ -479,6 +508,21 @@ describe("MatrixEventProcessor", () => {
             } as IMatrixEvent;
             await processor.ProcessStateEvent(event);
             expect(STATE_EVENT_MSG).to.equal("`@user:localhost` banned `@user2:localhost` from the room on Matrix.");
+        });
+        it("Should not echo bans", async () => {
+            const config = new DiscordBridgeConfig();
+            config.bridge.disableBanNotifications = true;
+            const {processor} =  createMatrixEventProcessor(0, bridge);
+            const event = {
+                content: {
+                    membership: "ban",
+                },
+                sender: "@user:localhost",
+                state_key: "@user2:localhost",
+                type: "m.room.member",
+            } as IMatrixEvent;
+            await processor.ProcessStateEvent(event);
+            expect(STATE_EVENT_MSG).to.equal("");
         });
     });
     describe("EventToEmbed", () => {


### PR DESCRIPTION
Fixes #866 

This implements config values to disable the rest of Matrix state changes (Bans, Kicks, Room Names). as well as add tests for them.