### PR TITLE
Fix matrix metrics handling

### DIFF
--- a/changelog.d/869.bugfix
+++ b/changelog.d/869.bugfix
@@ -1,0 +1,1 @@
+Fix a crash caused by processing metrics for Matrix events.

--- a/src/metrics.ts
+++ b/src/metrics.ts
@@ -69,7 +69,7 @@ export class PrometheusBridgeMetrics implements IBridgeMetrics {
     private remoteRequest: Histogram<string>;
     private matrixRequest: Histogram<string>;
     private requestsInFlight: Map<string, number>;
-    private matrixRequestStatus: Map<string, "success"|"failed">;
+    private matrixRequestStatus: Map<string, "success"|"failed"> = new Map();
     private httpServer: http.Server;
     private remoteMonthlyActiveUsers: Gauge<string>;
     private bridgeBlocked: Gauge<string>;
@@ -116,7 +116,7 @@ export class PrometheusBridgeMetrics implements IBridgeMetrics {
 
         this.matrixRequest = new Histogram({
             help: "Histogram of processing durations of received Matrix messages",
-            labelNames: ["outcome"],
+            labelNames: ["outcome", "method"],
             name: "matrix_request_seconds",
         });
         register.registerMetric(this.matrixRequest);
@@ -208,7 +208,7 @@ export class PrometheusBridgeMetrics implements IBridgeMetrics {
         this.matrixRequestStatus.delete(context.uniqueId);
         this.matrixRequest.observe({
             method: context.functionName,
-            result: successFail,
+            outcome: successFail,
         }, timeMs);
     }
 


### PR DESCRIPTION
This fixes 3 separate crashes seemingly introduced in ed62d8add13137a425f818ec4704c3b58fa111c4 that somehow slipped through for all this time – presumably due to metrics being off by default.