### PR TITLE
feat: add Matrix -> Discord reactions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM node:16-slim AS BUILD
-COPY . /tmp/src
 # install some dependencies needed for the build process
 RUN apt update && apt install -y build-essential make gcc g++ python3 ca-certificates libc-dev wget git
 
+COPY . /tmp/src
 RUN cd /tmp/src \
     && yarn
 

--- a/changelog.d/877.md
+++ b/changelog.d/877.md
@@ -1,0 +1,5 @@
+Adds one-way reaction support from Matrix -> Discord.
+
+This will only respond to the first reaction of each emoji and is intended for cases where the bridge is used by a single matrix user.
+
+Set `bridge.enableMatrixReactions` to `true` to enable this feature

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -38,7 +38,7 @@ bridge:
   disableInviteNotifications: false
   # Disable Room Topic echos from matrix
   disableRoomTopicNotifications: false
-  # Enable reactions from matrix to discord. This will only respond to
+  # Enable reactions from Matrix to Discord. This will only respond to
   # the first reaction of each emoji and is intended for cases where
   # the bridge is used by a single matrix used
   enableMatrixReactions: false

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -38,6 +38,10 @@ bridge:
   disableInviteNotifications: false
   # Disable Room Topic echos from matrix
   disableRoomTopicNotifications: false
+  # Enable reactions from matrix to discord. This will only respond to
+  # the first reaction of each emoji and is intended for cases where
+  # the bridge is used by a single matrix used
+  enableMatrixReactions: false
   # Auto-determine the language of code blocks (this can be CPU-intensive)
   determineCodeLanguage: false
   # MXID of an admin user that will be PMd if the bridge experiences problems. Optional

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -40,7 +40,7 @@ bridge:
   disableRoomTopicNotifications: false
   # Enable reactions from Matrix to Discord. This will only respond to
   # the first reaction of each emoji and is intended for cases where
-  # the bridge is used by a single matrix used
+  # the bridge is used by a single matrix user
   enableMatrixReactions: false
   # Auto-determine the language of code blocks (this can be CPU-intensive)
   determineCodeLanguage: false

--- a/config/config.schema.yaml
+++ b/config/config.schema.yaml
@@ -32,6 +32,8 @@ properties:
             type: "boolean"
           disableRoomTopicNotifications:
             type: "boolean"
+          enableMatrixReactions:
+            type: "boolean"
           userActivity:
             type: "object"
             required: ["minUserActiveDays", "inactiveAfterDays"]

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -726,13 +726,13 @@ export class DiscordBot {
 
         const relatesTo = event.content['m.relates_to'];
 
+        let emoji = relatesTo.key
+        if (emoji.indexOf("👍") >=0  ) {
+            emoji = "👍"
+        } 
+
         const matrixID = `${relatesTo.event_id};${event.room_id}`
         const storeEvent = await this.store.Get(DbEvent, { matrix_id: matrixID });
-        const storeReaction = await this.store.Get(DbReaction, { matrix_id: matrixID, emoji: relatesTo.key });
-
-        if (storeReaction && storeReaction.Result) {
-            log.verbose(`ignoring duplicate reaction`)
-        }
 
         if (!storeEvent || !storeEvent.Result) {
             log.warn(`Could not react because the event was not in the store.`);
@@ -747,7 +747,7 @@ export class DiscordBot {
             const msg = await chan.messages.fetch(storeEvent.DiscordId);
             try {
                 this.channelLock.set(msg.channel.id);
-                await msg.react(relatesTo.key);
+                await msg.react(emoji);
                 this.channelLock.release(msg.channel.id);
                 log.info(`Reacted to message`);
             } catch (ex) {
@@ -760,7 +760,7 @@ export class DiscordBot {
                 dbReaction.DiscordId = storeEvent.DiscordId;
                 dbReaction.ChannelId = storeEvent.ChannelId;
                 dbReaction.GuildId = storeEvent.GuildId;
-                dbReaction.Emoji = relatesTo.key;
+                dbReaction.Emoji = emoji;
                 await this.store.Insert(dbReaction);
             } catch (ex) {
                 log.warn(`Failed to store reaction event`)

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -700,7 +700,7 @@ export class DiscordBot {
         }
         log.info(`React event matched ${storeEvent.ResultCount} entries`);
         while (storeEvent.Next()) {
-            log.info(`Reacting to discord msg ${storeEvent.DiscordId}`);
+            log.info(`Reacting to Discord msg ${storeEvent.DiscordId}`);
             const result = await this.LookupRoom(storeEvent.GuildId, storeEvent.ChannelId, event.sender);
             const chan = result.channel;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -98,6 +98,7 @@ export class DiscordBridgeConfigBridge {
     public disableJoinLeaveNotifications: boolean = false;
     public disableInviteNotifications: boolean = false;
     public disableRoomTopicNotifications: boolean = false;
+    public enableMatrixReactions: boolean = false;
     public determineCodeLanguage: boolean = false;
     public activityTracker: UserActivityTrackerConfig = UserActivityTrackerConfig.DEFAULT;
     public userLimit: number|null = null;

--- a/src/db/dbdatareaction.ts
+++ b/src/db/dbdatareaction.ts
@@ -1,0 +1,159 @@
+/*
+Copyright 2017, 2018 matrix-appservice-discord
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { DiscordStore } from "../store";
+import { ISqlCommandParameters } from "./connector";
+import { IDbDataMany } from "./dbdatainterface";
+
+export class DbReaction implements IDbDataMany {
+    public MatrixId: string;
+    public DiscordId: string;
+    public GuildId: string;
+    public ChannelId: string;
+    public Result: boolean;
+    public Emoji: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private rows: any[];
+
+    get ResultCount(): number {
+        return this.rows.length;
+    }
+
+    public async RunQuery(store: DiscordStore, params: ISqlCommandParameters): Promise<void> {
+        this.rows = [];
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let rowsM: any[] | null = null;
+        if (params.matrix_id && params.emoji) {
+            rowsM = await store.db.All(`
+                SELECT *
+                FROM reaction_store
+                WHERE matrix_id = $id AND emoji = $emoji`, {
+                id: params.matrix_id,
+                emoji: params.emoji,
+            });
+        } else if (params.matrix_id) {
+            rowsM = await store.db.All(`
+                SELECT *
+                FROM reaction_store
+                WHERE matrix_id = $id`, {
+                id: params.matrix_id
+            });
+        } else if (params.discord_id) {
+            rowsM = await store.db.All(`
+                SELECT *
+                FROM reaction_store
+                WHERE discord_id = $id`, {
+                id: params.discord_id,
+            });
+        } else {
+            throw new Error("Unknown/incorrect id given as a param");
+        }
+
+        for (const rowM of rowsM) {
+            const row = {
+                /* eslint-disable @typescript-eslint/naming-convention */
+                discord_id: rowM.discord_id,
+                matrix_id: rowM.matrix_id,
+                emoji: rowM.emoji,
+                /* eslint-enable @typescript-eslint/naming-convention */
+            };
+            for (const rowD of await store.db.All(`
+                    SELECT *
+                    FROM discord_msg_store
+                    WHERE msg_id = $id`, {
+                id: rowM.discord_id,
+            })) {
+                this.rows.push({
+                    /* eslint-disable @typescript-eslint/naming-convention */
+                    ...row,
+                    guild_id: rowD.guild_id,
+                    channel_id: rowD.channel_id,
+                    /* eslint-enable @typescript-eslint/naming-convention */
+                });
+            }
+        }
+        this.Result = this.rows.length !== 0;
+    }
+
+    public Next(): boolean {
+        if (!this.Result || this.ResultCount === 0) {
+            return false;
+        }
+        const item = this.rows.shift();
+        this.MatrixId = item.matrix_id;
+        this.DiscordId = item.discord_id;
+        this.Emoji = item.emoji;
+        this.GuildId = item.guild_id;
+        this.ChannelId = item.channel_id;
+        return true;
+    }
+
+    public async Insert(store: DiscordStore): Promise<void> {
+        await store.db.Run(`
+            INSERT INTO reaction_store
+			(matrix_id,discord_id,emoji)
+			VALUES ($matrix_id,$discord_id,$emoji);`, {
+            /* eslint-disable @typescript-eslint/naming-convention */
+            discord_id: this.DiscordId,
+            matrix_id: this.MatrixId,
+            emoji: this.Emoji,
+            /* eslint-enable @typescript-eslint/naming-convention */
+        });
+        // Check if the discord item exists?
+        const msgExists = await store.db.Get(`
+                SELECT *
+                FROM discord_msg_store
+                WHERE msg_id = $id`, {
+            id: this.DiscordId,
+        }) != null;
+        if (msgExists) {
+            return;
+        }
+        return store.db.Run(`
+            INSERT INTO discord_msg_store
+            (msg_id, guild_id, channel_id)
+            VALUES ($msg_id, $guild_id, $channel_id);`, {
+            /* eslint-disable @typescript-eslint/naming-convention */
+            channel_id: this.ChannelId,
+            guild_id: this.GuildId,
+            msg_id: this.DiscordId,
+            /* eslint-enable @typescript-eslint/naming-convention */
+        });
+    }
+
+    public async Update(store: DiscordStore): Promise<void> {
+        throw new Error("Update is not implemented");
+    }
+
+    public async Delete(store: DiscordStore): Promise<void> {
+        await store.db.Run(`
+            DELETE FROM reaction_store
+            WHERE matrix_id = $matrix_id
+            AND discord_id = $discord_id;`, {
+            /* eslint-disable @typescript-eslint/naming-convention */
+            discord_id: this.DiscordId,
+            matrix_id: this.MatrixId,
+            /* eslint-enable @typescript-eslint/naming-convention */
+        });
+        return store.db.Run(`
+            DELETE FROM discord_msg_store
+            WHERE msg_id = $discord_id;`, {
+            /* eslint-disable @typescript-eslint/naming-convention */
+            discord_id: this.DiscordId,
+            /* eslint-enable @typescript-eslint/naming-convention */
+        });
+    }
+}

--- a/src/db/schema/v13.ts
+++ b/src/db/schema/v13.ts
@@ -1,0 +1,37 @@
+/*
+Copyright 2017, 2018 matrix-appservice-discord
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { DiscordStore } from "../../store";
+import { IDbSchema } from "./dbschema";
+
+export class Schema implements IDbSchema {
+    public description = "create event_store table";
+    public async run(store: DiscordStore): Promise<void> {
+        await store.createTable(`
+            CREATE TABLE reaction_store (
+                matrix_id TEXT NOT NULL,
+				discord_id TEXT NOT NULL,
+				emoji TEXT NOT NULL,
+                PRIMARY KEY(matrix_id, discord_id)
+        );`, "event_store");
+    }
+
+    public async rollBack(store: DiscordStore): Promise<void> {
+        await store.db.Run(
+            `DROP TABLE IF EXISTS reaction_store;`,
+        );
+    }
+}

--- a/src/matrixeventprocessor.ts
+++ b/src/matrixeventprocessor.ts
@@ -133,6 +133,9 @@ export class MatrixEventProcessor {
         } else if (event.type === "m.room.redaction" && remoteRoom) {
             await this.discord.ProcessMatrixRedact(event);
             return;
+        } else if (event.type === "m.reaction" && remoteRoom) {
+            await this.discord.ProcessMatrixReaction(event);
+            return;
         } else if (event.type === "m.room.message" || event.type === "m.sticker") {
             log.verbose(`Got ${event.type} event`);
             if (isBotCommand(event)) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -27,7 +27,7 @@ import { DbUserStore } from "./db/userstore";
 import { IAppserviceStorageProvider } from "matrix-bot-sdk";
 import { UserActivitySet, UserActivity } from "matrix-appservice-bridge";
 const log = new Log("DiscordStore");
-export const CURRENT_SCHEMA = 12;
+export const CURRENT_SCHEMA = 13;
 /**
  * Stores data for specific users and data not specific to rooms.
  */

--- a/test/test_matrixeventprocessor.ts
+++ b/test/test_matrixeventprocessor.ts
@@ -213,6 +213,9 @@ function createMatrixEventProcessor(storeMockResults = 0, configBridge = new Dis
         ProcessMatrixRedact: async (evt) => {
             MESSAGE_PROCCESS = "redacted";
         },
+        ProcessMatrixReaction: async (evt) => {
+            MESSAGE_PROCCESS = "reacted";
+        },
         UserSyncroniser: us,
         edit: async (embedSet, opts, roomLookup, event) => {
             MESSAGE_EDITED = true;
@@ -1044,6 +1047,22 @@ This is the reply`,
             await processor.OnEvent(buildRequest({
                     type: "m.room.redaction"}), context);
             expect(MESSAGE_PROCCESS).equals("");
+        });
+        it("should handle reactions from matrix", async () => {
+            const { processor } = createMatrixEventProcessor();
+            const context = {
+                rooms: {
+                    remote: true,
+                },
+            };
+            await processor.OnEvent(buildRequest({
+                type: "m.reaction"
+            }), [{
+                id: "foo",
+                matrix: {} as any,
+                remote: {} as any,
+            }]);
+            expect(MESSAGE_PROCCESS).equals("reacted");
         });
         it("should process regular messages", async () => {
             const {processor} =  createMatrixEventProcessor();


### PR DESCRIPTION
Implements reactions from matrix to discord, intended for cases where a single matrix user is using the bot as a personal puppet

Functionality is disabled by default and enable by setting `bridge.enableMatrixReactions` to `true`

- [x] Send reactions to discord from Matrix to Discord
- [x] Removes reactions when redacted in Matrix
- [x] Handle thumbs up exception from Matrix to Discord
- [ ] Handle thumbs up exception from Discord to Matrix