### PR TITLE
Prefer server-level display names when available

### DIFF
--- a/changelog.d/888.bugfix
+++ b/changelog.d/888.bugfix
@@ -1,0 +1,1 @@
+Prefer server-level display names when available.

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -1027,7 +1027,7 @@ export class DiscordBot {
         }
 
         // Update presence because sometimes discord misses people.
-        await this.userSync.OnUpdateUser(msg.author, Boolean(msg.webhookID));
+        await this.userSync.OnUpdateUser(msg.author, Boolean(msg.webhookID), msg);
         let rooms: string[];
         try {
             rooms = await this.channelSync.GetRoomIdsFromChannel(msg.channel);

--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { User, GuildMember } from "better-discord.js";
+import { User, GuildMember, Message } from "better-discord.js";
 import { DiscordBot } from "./bot";
 import { Util } from "./util";
 import { DiscordBridgeConfig } from "./config";
@@ -96,8 +96,8 @@ export class UserSyncroniser {
      * @returns {Promise<void>}
      * @constructor
      */
-    public async OnUpdateUser(discordUser: User, isWebhook: boolean = false) {
-        const userState = await this.GetUserUpdateState(discordUser, isWebhook);
+    public async OnUpdateUser(discordUser: User, isWebhook: boolean = false, msg?: Message) {
+        const userState = await this.GetUserUpdateState(discordUser, isWebhook, msg);
         try {
             await this.ApplyStateToProfile(userState);
         } catch (e) {
@@ -230,7 +230,7 @@ export class UserSyncroniser {
         }
     }
 
-    public async GetUserUpdateState(discordUser: User, isWebhook: boolean = false): Promise<IUserState> {
+    public async GetUserUpdateState(discordUser: User, isWebhook: boolean = false, msg?: Message): Promise<IUserState> {
         log.verbose(`State update requested for ${discordUser.id}`);
         let mxidExtra = "";
         if (isWebhook) {
@@ -244,7 +244,7 @@ export class UserSyncroniser {
             id: discordUser.id + mxidExtra,
             mxUserId: `@_discord_${discordUser.id}${mxidExtra}:${this.config.bridge.domain}`,
         });
-        const displayName = Util.ApplyPatternString(this.config.ghosts.usernamePattern, {
+        const displayName = msg?.member?.nickname || Util.ApplyPatternString(this.config.ghosts.usernamePattern, {
             id: discordUser.id,
             tag: discordUser.discriminator,
             username: discordUser.username,


### PR DESCRIPTION
Sometimes server-level displayName values don't propagate correctly onto Matrix. This fixes that. Apparently you can't get the user-level display name in DiscordJS yet except in the dev version, and you're on a fork of a fork of a fork of that so I'm just no messing with it.

Signed-off-by: `Bob Arctor <neetzsche@tutanota.com>`