### PR TITLE
Add Discord Announcement channels to allowed bridging types

### DIFF
--- a/changelog.d/889.bugfix
+++ b/changelog.d/889.bugfix
@@ -1,0 +1,2 @@
+It is now possible to bridge a matrix channel with a Discord Announcement/News
+channel. Contributed by @frostyfrog.

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -471,7 +471,7 @@ export class DiscordBot {
                 throw new Error(`Guild "${server}" not found`);
             }
             const channel = guild.channels.resolve(room);
-            if (channel && channel.type === "text") {
+            if (channel && ["text", "news"].includes(channel.type)) {
                 if (hasSender) {
                     const permissions = guild.me && channel.permissionsFor(guild.me);
                     if (!permissions || !permissions.has("VIEW_CHANNEL") || !permissions.has("SEND_MESSAGES")) {

--- a/test/mocks/channel.ts
+++ b/test/mocks/channel.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import {MockMember} from "./member";
 import {MockCollection} from "./collection";
-import {Permissions, PermissionResolvable, TextChannel} from "better-discord.js";
+import {Permissions, PermissionResolvable, TextChannel, NewsChannel} from "better-discord.js";
 import { MockGuild } from "./guild";
 
 // we are a test file and thus need those
@@ -43,6 +43,19 @@ export class MockChannel {
 }
 
 export class MockTextChannel extends TextChannel {
+    constructor(guild?: MockGuild, channelData: any = {}) {
+        // Mock the nessacery
+        super(guild || {
+            client: {
+                options: {
+                    messageCacheMaxSize: -1,
+                },
+            },
+        } as any, channelData);
+    }
+}
+
+export class MockNewsChannel extends NewsChannel {
     constructor(guild?: MockGuild, channelData: any = {}) {
         // Mock the nessacery
         super(guild || {

--- a/test/mocks/message.ts
+++ b/test/mocks/message.ts
@@ -25,11 +25,11 @@ export class MockMessage {
     public attachments = new MockCollection<string, any>();
     public embeds: any[] = [];
     public content = "";
-    public channel: Discord.TextChannel | undefined;
+    public channel: Discord.TextChannel | Discord.NewsChannel | undefined;
     public guild: Discord.Guild | undefined;
     public author: MockUser;
     public mentions: any = {};
-    constructor(channel?: Discord.TextChannel) {
+    constructor(channel?: Discord.TextChannel | Discord.NewsChannel) {
         this.mentions.everyone = false;
         this.channel = channel;
         if (channel && channel.guild) {

--- a/test/test_discordmessageprocessor.ts
+++ b/test/test_discordmessageprocessor.ts
@@ -20,7 +20,7 @@ import { DiscordBot } from "../src/bot";
 import { MockGuild } from "./mocks/guild";
 import { MockMember } from "./mocks/member";
 import { MockMessage } from "./mocks/message";
-import { MockTextChannel } from "./mocks/channel";
+import { MockTextChannel, MockNewsChannel } from "./mocks/channel";
 
 // we are a test file and thus need those
 /* tslint:disable:no-unused-expression max-file-line-count no-any */
@@ -208,7 +208,7 @@ describe("DiscordMessageProcessor", () => {
             expect(result.body).to.equal("Hello <#3333333>");
             expect(result.formattedBody).to.equal("Hello &lt;#3333333&gt;");
         });
-        it("processes channels correctly", async () => {
+        it("processes text channels correctly", async () => {
             const processor = new DiscordMessageProcessor(
                 "localhost", bot as DiscordBot);
             const guild: any = new MockGuild("123", []);
@@ -221,6 +221,20 @@ describe("DiscordMessageProcessor", () => {
             expect(result.body).to.equal("Hello #TestChannel");
             expect(result.formattedBody).to.equal("Hello <a href=\"https://matrix.to/#/#_discord_123" +
                 "_456:localhost\">#TestChannel</a>");
+        });
+        it("processes news channels correctly", async () => {
+            const processor = new DiscordMessageProcessor(
+                "localhost", bot as DiscordBot);
+            const guild: any = new MockGuild("123", []);
+            const channel = new MockNewsChannel(guild, {id: "456", name: "TestNewsChannel"});
+            guild.channels.cache.set("456", channel);
+            const msg = new MockMessage(channel) as any;
+            msg.embeds = [];
+            msg.content = "Hello <#456>";
+            const result = await processor.FormatMessage(msg);
+            expect(result.body).to.equal("Hello #TestNewsChannel");
+            expect(result.formattedBody).to.equal("Hello <a href=\"https://matrix.to/#/#_discord_123" +
+                "_456:localhost\">#TestNewsChannel</a>");
         });
         it("processes channels without alias correctly", async () => {
             const processor = new DiscordMessageProcessor(


### PR DESCRIPTION
Add the News/Announcement channel type to the list of allowed channel types to bridge between. This can be useful for administrators to centralize announcements between services to reduce the ammount of busy-work that they may need to do.

This fixes #774 and it fixes #813, which is a duplicate 
<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honestly).
-->
