### PR TITLE
Apply nick pattern to user updates

### DIFF
--- a/changelog.d/891.bugfix
+++ b/changelog.d/891.bugfix
@@ -1,0 +1,2 @@
+Fixed an odd case where ghost users' names in Matrix would update, ignoring the
+nickPattern config value. Contributed by @frostyfrog.

--- a/src/usersyncroniser.ts
+++ b/src/usersyncroniser.ts
@@ -319,9 +319,17 @@ export class UserSyncroniser {
             // userstate changes
             mxidExtra = "_" + Util.ParseMxid(`@${user.username}`, false).localpart;
         }
+        const name = Util.ApplyPatternString(this.config.ghosts.nickPattern, {
+            id: user.id,
+						// Currently, the discord.js doesn't support global nicknames, so use the
+						// user's username instead
+            nick: user.username, // newMember.displayName,
+            tag: user.discriminator,
+            username: user.username,
+        });
         const guildState: IGuildMemberState = Object.assign({}, DEFAULT_GUILD_STATE, {
             bot: user.bot,
-            displayName: user.username,
+            displayName: name,
             id: user.id + mxidExtra,
             mxUserId: `@_discord_${user.id}${mxidExtra}:${this.config.bridge.domain}`,
             roles: [],

--- a/test/test_usersyncroniser.ts
+++ b/test/test_usersyncroniser.ts
@@ -544,6 +544,15 @@ describe("UserSyncroniser", () => {
             const state = await userSync.GetUserStateForDiscordUser(member as any);
             expect(state.displayName).to.be.equal("username");
         });
+        it("Will will obay nick pattern", async () => {
+            const {userSync, bridge} = CreateUserSync([new RemoteUser("123456")], { nickPattern: ":nick (Discord)" });
+            const member = new MockUser(
+                "123456",
+                "username",
+                "1234");
+            const state = await userSync.GetUserStateForDiscordUser(member as any);
+            expect(state.displayName).to.be.equal("username (Discord)");
+        });
         it("Will handle webhooks", async () => {
             const {userSync, bridge} = CreateUserSync([new RemoteUser("123456")]);
             const member = new MockUser(


### PR DESCRIPTION
When a nickname is updated for a user, and it isn't updated as a GuildMember object, we fail to apply the nick pattern to the Matrix nickname for the ghost user. By using the same logic as the GetUserStateForGuildMember in GetUserStateForDiscordUser, the nickname should now match the nickname pattern. Hopefully this will cut back on nickname changes being echoed out in Matrix channels, when no changes were made in the first place. At the very least, if a prefix/suffix is added to usernames, those should remain on the user at all times now.

<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honestly).
-->
