### PR TITLE
chore: remove embed on discord edits

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -567,7 +567,7 @@ export class DiscordBot {
                 return;
             }
             const link = `https://discord.com/channels/${chan.guild.id}/${chan.id}/${editEventId}`;
-            embedSet.messageEmbed.description = `[Edit](${link}): ${embedSet.messageEmbed.description}`;
+            embedSet.messageEmbed.description = `[Edit](<${link}>): ${embedSet.messageEmbed.description}`;
             await this.send(embedSet, opts, roomLookup, event);
         } catch (err) {
             // throw wrapError(err, Unstable.ForeignNetworkError, "Couldn't edit message");


### PR DESCRIPTION
Simple fix to remove the massive embeds since discord changed their embeds. The discord side is becoming unusable when people on matrix edit their messages;

![image](https://github.com/matrix-org/matrix-appservice-discord/assets/57440386/d81b75db-56f9-4361-b8b5-36ca288e690d)

I'm open to fixing this PR or changing it to simply edit the actual webhook message, as per [my message in matrix](https://matrix.to/#/!CLqUgGcItOCvwmZRvW:half-shot.uk/$GOpZb0Koav6Nnn3AZRTieklZrhjOe0tKDUCHjaQxzgI?via=half-shot.uk&via=matrix.org&via=tchncs.de) (hopefully this works fine)