### PR TITLE
config: set missing defaults

### DIFF
--- a/changelog.d/917.bugfix
+++ b/changelog.d/917.bugfix
@@ -1,0 +1,1 @@
+Fix some config parameters not being overridable with env vars.

--- a/src/config.ts
+++ b/src/config.ts
@@ -81,18 +81,18 @@ export class DiscordBridgeConfig {
 }
 
 export class DiscordBridgeConfigBridge {
-    public domain: string;
-    public homeserverUrl: string;
-    public port: number;
-    public bindAddress: string;
+    public domain: string = "";
+    public homeserverUrl: string = "";
+    public port: number = 0;
+    public bindAddress: string = "";
     public presenceInterval: number = 500;
-    public disablePresence: boolean;
-    public disableTypingNotifications: boolean;
-    public disableDiscordMentions: boolean;
-    public disableDeletionForwarding: boolean;
-    public enableSelfServiceBridging: boolean;
-    public disablePortalBridging: boolean;
-    public disableReadReceipts: boolean;
+    public disablePresence: boolean = false;
+    public disableTypingNotifications: boolean = false;
+    public disableDiscordMentions: boolean = false;
+    public disableDeletionForwarding: boolean = false;
+    public enableSelfServiceBridging: boolean = false;
+    public disablePortalBridging: boolean = false;
+    public disableReadReceipts: boolean = false;
     public disableEveryoneMention: boolean = false;
     public disableHereMention: boolean = false;
     public disableJoinLeaveNotifications: boolean = false;
@@ -106,17 +106,17 @@ export class DiscordBridgeConfigBridge {
 }
 
 export class DiscordBridgeConfigDatabase {
-    public connString: string;
-    public filename: string;
+    public connString: string = "";
+    public filename: string = "";
     // These parameters are legacy, and will stop the bridge if defined.
-    public userStorePath: string;
-    public roomStorePath: string;
+    public userStorePath: string = "";
+    public roomStorePath: string = "";
 }
 
 export class DiscordBridgeConfigAuth {
-    public clientID: string;
-    public botToken: string;
-    public usePrivilegedIntents: boolean;
+    public clientID: string = "";
+    public botToken: string = "";
+    public usePrivilegedIntents: boolean = false;
 }
 
 export class DiscordBridgeConfigLogging {
@@ -126,7 +126,7 @@ export class DiscordBridgeConfigLogging {
 }
 
 class DiscordBridgeConfigRoom {
-    public defaultVisibility: string;
+    public defaultVisibility: string = "";
     public kickFor: number = 30000;
 }
 
@@ -152,7 +152,7 @@ class DiscordBridgeConfigLimits {
 }
 
 export class LoggingFile {
-    public file: string;
+    public file: string = "";
     public level: string = "info";
     public maxFiles: string = "14d";
     public maxSize: string|number = "50m";

--- a/test/test_config.ts
+++ b/test/test_config.ts
@@ -63,6 +63,7 @@ describe("DiscordBridgeConfig.applyConfig", () => {
             APPSERVICE_DISCORD_BRIDGE_DISABLE_INVITE_NOTIFICATIONS: true,
             APPSERVICE_DISCORD_BRIDGE_DISABLE_JOIN_LEAVE_NOTIFICATIONS: true,
             APPSERVICE_DISCORD_LOGGING_CONSOLE: "debug",
+            APPSERVICE_DISCORD_DATABASE_CONN_STRING: "abcd",
         });
         expect(config.bridge.disableJoinLeaveNotifications).to.be.true;
         expect(config.bridge.disableInviteNotifications).to.be.true;
@@ -70,6 +71,7 @@ describe("DiscordBridgeConfig.applyConfig", () => {
         expect(config.bridge.disableDiscordMentions).to.be.false;
         expect(config.bridge.homeserverUrl).to.equal("blah");
         expect(config.logging.console).to.equal("debug");
+        expect(config.database.connString).to.equal("abcd");
     });
     it("should merge logging.files correctly", () => {
         const config = new DiscordBridgeConfig();


### PR DESCRIPTION
This allows using env vars for all config parameters. I also suppose that considering the fields aren't marked as optional with question marks, it's a good practice to add some non-null defaults.

<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honestly).
-->
