### PR TITLE
Don't send filenames in discord message bodies

### DIFF
--- a/changelog.d/918.misc
+++ b/changelog.d/918.misc
@@ -1,0 +1,1 @@
+Don't send filenames in message body when bridging Matrix -> Discord.

--- a/src/matrixeventprocessor.ts
+++ b/src/matrixeventprocessor.ts
@@ -299,7 +299,7 @@ export class MatrixEventProcessor {
         }
 
         let body: string = "";
-        if (event.type !== "m.sticker") {
+        if (!this.HasAttachment(event)) {
             const content = event.content!["m.new_content"] ? event.content!["m.new_content"] : event.content;
             body = await this.matrixMsgProcessor.FormatMessage(content as IMatrixMessage, channel.guild, params);
         }

--- a/test/test_matrixeventprocessor.ts
+++ b/test/test_matrixeventprocessor.ts
@@ -638,6 +638,35 @@ describe("MatrixEventProcessor", () => {
             } as IMatrixEvent, mockChannel as any);
             expect(embeds.messageEmbed.description).to.equal("Bunnies\n(<@1234>)");
         });
+        it("Should not send filename in body", async () => {
+            const {processor} =  createMatrixEventProcessor();
+            const embeds = await processor.EventToEmbed({
+                content: {
+                    body: "filename.zip",
+                    msgtype: "m.file",
+                    url: "mxc://file",
+                },
+                sender: "@test:localhost",
+                type: "m.room.member",
+            } as IMatrixEvent, mockChannel as any);
+            expect(embeds.messageEmbed.description).to.equal("");
+        });
+        it("Should not send image filename in body", async () => {
+            const {processor} =  createMatrixEventProcessor();
+            const embeds = await processor.EventToEmbed({
+                content: {
+                    body: "filename.jpg",
+                    info: {
+                        mimetype: "image/jpeg",
+                    },
+                    msgtype: "m.image",
+                    url: "mxc://image",
+                },
+                sender: "@test:localhost",
+                type: "m.room.member",
+            } as IMatrixEvent, mockChannel as any);
+            expect(embeds.messageEmbed.description).to.equal("");
+        });
     });
     describe("HandleAttachment", () => {
         const SMALL_FILE = 200;
@@ -939,7 +968,7 @@ This is the reply`,
                 type: "m.room.message",
             } as IMatrixEvent, mockChannel as any);
             expect(result!.image!.url!).to.be.equal("https://fox/localhost");
-            expect(result!.description).to.be.equal("fox.jpg");
+            expect(result!.description).to.be.equal("");
         });
         it("should handle replies to files", async () => {
             const {processor} =  createMatrixEventProcessor();


### PR DESCRIPTION
Previously, whenever you sent a file/image on Matrix, the file name would be sent on the Discord end as the body text *alongside* the attachment. This removes that behavior.

<!--
Hi there 👋, please check you've read the [CONTRIBUTING](../CONTRIBUTING.md) guide before submitting a PR (it's worth it, honestly).
-->
