### PR TITLE
mention Message Content Intent

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ should show up in the network list on Element and other clients.
 ### Setting up Discord
 
 * Create a new application via https://discord.com/developers/applications
-* Make sure to create a bot user. Fill in ``config.yaml``
+* Make sure to create a bot user with "Message Content Intent" enabled. Fill in ``config.yaml``
 * Run ``yarn addbot`` to get a authorisation link.
 * Give this link to owners of the guilds you plan to bridge.
 * Finally, you can join a room with ``#_discord_guildid_channelid``


### PR DESCRIPTION
This issue took us a few hours to debug - would be nice to have it in the readme.

if Message Content Intent is not enabled, the appservice will receive empty messages from Discord, and discard them.